### PR TITLE
add prompt injection udf and rename similiarity

### DIFF
--- a/langkit/injections.py
+++ b/langkit/injections.py
@@ -1,0 +1,19 @@
+from whylogs.experimental.core.udf_schema import register_dataset_udf
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    TextClassificationPipeline,
+)
+model_path = "JasperLS/gelectra-base-injection"
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+model = AutoModelForSequenceClassification.from_pretrained(model_path)
+
+pipeline = TextClassificationPipeline(model=model, tokenizer=tokenizer)
+
+@register_dataset_udf(['prompt'], "prompt.injection")
+def injection(text: str) -> float:
+    result = pipeline(text['prompt'])
+    injection_score = (
+        result[0]["score"] if result[0]["label"] == "INJECTION" else 1 - result[0]["score"]
+    )
+    return injection_score

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -21,10 +21,9 @@ def init(transformer_name: Optional[str] = None):
 
 
 init()
-_udf_name = _transformer_name or lang_config.transformer_name
 
 
-@register_dataset_udf(["prompt", "response"], f"similarity_{_udf_name.split('/')[-1]}")
+@register_dataset_udf(["prompt", "response"], "response.relevance_to_prompt")
 def similarity_MiniLM_L6_v2(text):
     x = text["prompt"]
     y = text["response"]

--- a/langkit/tests/test_input_output.py
+++ b/langkit/tests/test_input_output.py
@@ -41,7 +41,7 @@ def test_similarity(interactions):
     schema = generate_udf_dataset_schema(default_config=MetricConfig(fi_disabled=True))
     for i, interaction in enumerate(interactions):
         result = why.log(interaction, schema=schema)
-        column_name = f"similarity_{lkio._transformer_name.split('/')[-1]}"
+        column_name = "response.relevance_to_prompt"
         if {"prompt", "response"}.issubset(set(interaction.keys())):
             similarity_median = (
                 result.view()


### PR DESCRIPTION
Adds a prompt injection surrogate model to the prompt column, renamed similarity to relevance and put under response namespace