### PR TITLE
Enable import has_patterns as standalone function

### DIFF
--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -69,19 +69,22 @@ class PatternLoader:
 
 
 pattern_loader = PatternLoader()
-if pattern_loader.get_regex_groups() is not None:
 
-    @register_metric_udf(col_type=String, type_mapper=AllString())
-    def has_patterns(text: str) -> Optional[str]:
-        regex_groups = pattern_loader.get_regex_groups()
-        patterns_info = None
-        if regex_groups:
-            for group in regex_groups:
-                for expression in group["expressions"]:
-                    if expression.search(text):
-                        patterns_info = group["name"]
-                        return group["name"]
-        return patterns_info
+
+def has_patterns(text: str) -> Optional[str]:
+    regex_groups = pattern_loader.get_regex_groups()
+    patterns_info = None
+    if regex_groups:
+        for group in regex_groups:
+            for expression in group["expressions"]:
+                if expression.search(text):
+                    patterns_info = group["name"]
+                    return group["name"]
+    return patterns_info
+
+
+if pattern_loader.get_regex_groups() is not None:
+    register_metric_udf(col_type=String, type_mapper=AllString())(has_patterns)
 
 
 def init(pattern_file_path: Optional[str] = None):


### PR DESCRIPTION
The function `has_patterns` can't be imported as a standalone function because it is defined inside a conditional block.

This PR moves the definition outside the if block, leaving only the udf metric registration inside the condition.