### PR TITLE
add encoding definition when loading themes json

### DIFF
--- a/langkit/themes.py
+++ b/langkit/themes.py
@@ -70,7 +70,7 @@ def refusal_similarity(text: str) -> Optional[float]:
 def load_themes(json_path: str):
     try:
         skip = False
-        with open(json_path, "r") as myfile:
+        with open(json_path, "r", encoding="utf-8") as myfile:
             theme_groups = json.load(myfile)
     except FileNotFoundError:
         skip = True

--- a/langkit/themes.py
+++ b/langkit/themes.py
@@ -67,10 +67,10 @@ def refusal_similarity(text: str) -> Optional[float]:
     return max(similarities) if similarities else None
 
 
-def load_themes(json_path: str):
+def load_themes(json_path: str, encoding="utf-8"):
     try:
         skip = False
-        with open(json_path, "r", encoding="utf-8") as myfile:
+        with open(json_path, "r", encoding=encoding) as myfile:
             theme_groups = json.load(myfile)
     except FileNotFoundError:
         skip = True


### PR DESCRIPTION
On Windows, loading the `themes` module hits the following decoding error:

`UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 7613: character maps to <undefined>`

To fix this, This PR adds `decoding` parameter to `utf-8` when loading the themes json file.