### PR TITLE
Add helper method to configure metadata logging

### DIFF
--- a/langkit/callback_handler.py
+++ b/langkit/callback_handler.py
@@ -227,6 +227,10 @@ def DynamicCallbackAdapter(Base):
         def include_metadata(self, value: bool = True):
             if hasattr(self._handler, "_log_metadata"):
                 self._handler._log_metadata = value
+            else:
+                diagnostic_logger.warning(
+                    f"called include_metadata but the {self._handler} does not have this ability, doing nothing."
+                )
 
         def __getattr__(self, name):
             if name in self._callbacks:

--- a/langkit/callback_handler.py
+++ b/langkit/callback_handler.py
@@ -222,6 +222,11 @@ def DynamicCallbackAdapter(Base):
                 )
             self._methods: Dict[str, Callable] = dict()
             self._logger = whylabs_logger
+            self._handler = handler
+
+        def include_metadata(self, value: bool = True):
+            if hasattr(self._handler, "_log_metadata"):
+                self._handler._log_metadata = value
 
         def __getattr__(self, name):
             if name in self._callbacks:
@@ -243,10 +248,11 @@ def DynamicCallbackAdapter(Base):
 
 def get_callback_instance(*args, **kwargs):
     handler = kwargs.get("handler")
+    log_metadata = kwargs.get("log_metadata", False)
     logger = kwargs.get("logger")
     if handler is None:
         logger = kwargs.get("logger")
-        handler = LangKitCallback(logger=logger)
+        handler = LangKitCallback(logger=logger, log_metadata=log_metadata)
     elif logger is None:
         logger = handler._logger
     base_class = handler.__class__

--- a/langkit/tests/test_callback_handler.py
+++ b/langkit/tests/test_callback_handler.py
@@ -103,7 +103,7 @@ def test_callback_instance_handler_with_metadata():
     universal_callback.include_metadata()
     test_prompts = ["goodbye!"]
     universal_callback.on_llm_start(prompts=test_prompts)
-    mock_response = type('MockResponse', (object,), {'generations': []})
+    mock_response = type("MockResponse", (object,), {"generations": []})
     universal_callback.on_llm_end(response=mock_response)
 
 

--- a/langkit/tests/test_callback_handler.py
+++ b/langkit/tests/test_callback_handler.py
@@ -95,6 +95,18 @@ def test_callback_instance_handler_defined():
     universal_callback.close()
 
 
+def test_callback_instance_handler_with_metadata():
+    callback_handler = LangKitCallback(logger=MockLogger())
+    universal_callback = get_callback_instance(
+        handler=callback_handler, impl=MockBaseHandler2
+    )
+    universal_callback.include_metadata()
+    test_prompts = ["goodbye!"]
+    universal_callback.on_llm_start(prompts=test_prompts)
+    mock_response = type('MockResponse', (object,), {'generations': []})
+    universal_callback.on_llm_end(response=mock_response)
+
+
 def test_callback_instance_handler_defined_getattr():
     callback_handler = LangKitCallback(logger=MockLogger())
     universal_callback = get_callback_instance(


### PR DESCRIPTION
Its messy to toggle the metadata collection in the LangChain integration without a helper like this.

With these changes you can do something like this:
```
from langchain.llms import OpenAI

whylabs = WhyLabsCallbackHandler.from_params()
whylabs.include_metadata()
llm = OpenAI(temperature=0, callbacks=[whylabs])

result = llm.generate(["Hello, World!"])
print(result)
```

output columns then are:
```
{'invocation_params.model_name': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc254ab460>,
 'invocation_params.temperature': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc25d802e0>,
 'invocation_params.max_tokens': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc3541a3e0>,
 'invocation_params.top_p': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc3541a830>,
 'invocation_params.frequency_penalty': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc686221a0>,
 'invocation_params.presence_penalty': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc1f608430>,
 'invocation_params.n': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc68621c60>,
 'invocation_params.request_timeout': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc686214b0>,
 'invocation_params.logit_bias': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc2553bd30>,
 'invocation_params._type': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc1f608790>,
 'invocation_params.stop': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc2553bee0>,
 'response_latency_s': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc1f608dc0>,
 'response': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc2553beb0>,
 'prompt': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc2553bf70>,
 'completion_tokens': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc1f608d90>,
 'prompt_tokens': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc1f608040>,
 'total_tokens': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x7cfc1f6087f0>}
 ```
run unit test like this:
```
poetry run pytest langkit/tests/test_callback_handler.py::test_callback_instance_handler_with_metadata -o log_level=INFO -o log_cli=true
```
unit test output look like this:

```
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.2.0
rootdir: /home/jamie/projects/v1/TextMetricsToolkit
collecting ... 
------------------------------------------------------------------------------------------------ live log collection -------------------------------------------------------------------------------------------------
INFO     numexpr.utils:utils.py:148 Note: NumExpr detected 16 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
INFO     numexpr.utils:utils.py:160 NumExpr defaulting to 8 threads.
collected 1 item                                                                                                                                                                                                     

langkit/tests/test_callback_handler.py::test_callback_instance_handler_with_metadata 
--------------------------------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------------------------------
INFO     langkit.callback_handler:callback_handler.py:62 Initialized LangKitCallback handler with configured whylogs Logger <langkit.tests.test_callback_handler.MockLogger object at 0x7f6cc570f520>.
INFO     langkit.callback_handler:callback_handler.py:34 missing arg serialized, passing in serialized=None
INFO     langkit.callback_handler:callback_handler.py:34 missing arg kwargs, passing in kwargs=None
INFO     langkit.callback_handler:callback_handler.py:34 missing arg kwargs, passing in kwargs=None
INFO     langkit.tests.test_callback_handler:test_callback_handler.py:12 logger called log(*args=({'response_latency_s': 0.0002646446228027344},), **kwargs={})
```