### PR TITLE
Fix some config issues

### DIFF
--- a/langkit/__init__.py
+++ b/langkit/__init__.py
@@ -17,8 +17,6 @@ class LangKitConfig:
         default_factory=lambda: _resource_filename("themes.json")
     )
     transformer_name: str = "sentence-transformers/all-MiniLM-L6-v2"
-    prompt_column: str = "prompt"
-    response_column: str = "response"
     topics: list = field(
         default_factory=lambda: [
             "law",
@@ -39,6 +37,8 @@ class LangKitConfig:
     reference_corpus: str = ""
 
 
+prompt_column: str = "prompt"
+response_column: str = "response"
 lang_config = LangKitConfig()
 
 

--- a/langkit/__init__.py
+++ b/langkit/__init__.py
@@ -39,6 +39,9 @@ class LangKitConfig:
     reference_corpus: str = ""
 
 
+lang_config = LangKitConfig()
+
+
 def package_version(package: str = __package__) -> str:
     """Calculate version number based on pyproject.toml"""
     try:

--- a/langkit/injections.py
+++ b/langkit/injections.py
@@ -1,9 +1,8 @@
 from typing import Dict, List, Optional, Union
 from whylogs.core.stubs import pd
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import LangKitConfig
+from . import lang_config
 
-lang_config = LangKitConfig()
 _prompt = lang_config.prompt_column
 
 _model_path = "JasperLS/gelectra-base-injection"

--- a/langkit/injections.py
+++ b/langkit/injections.py
@@ -1,9 +1,9 @@
 from typing import Dict, List, Optional, Union
 from whylogs.core.stubs import pd
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import lang_config
+from . import prompt_column
 
-_prompt = lang_config.prompt_column
+_prompt = prompt_column
 
 _model_path = "JasperLS/gelectra-base-injection"
 _tokenizer = None

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -6,9 +6,11 @@ from whylogs.experimental.core.udf_schema import register_dataset_udf
 
 from langkit.transformer import load_model
 
-from . import LangKitConfig
+from . import lang_config
 
-lang_config = LangKitConfig()
+_prompt = lang_config.prompt_column
+_response = lang_config.response_column
+
 _transformer_model = None
 _transformer_name = None
 
@@ -26,7 +28,7 @@ def init(transformer_name: Optional[str] = None):
 init()
 
 
-@register_dataset_udf(["prompt", "response"], "response.relevance_to_prompt")
+@register_dataset_udf([_prompt, _response], f"{_response}.relevance_to_prompt")
 def similarity_MiniLM_L6_v2(text):
     if _transformer_model is None:
         raise ValueError(

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -6,10 +6,10 @@ from whylogs.experimental.core.udf_schema import register_dataset_udf
 
 from langkit.transformer import load_model
 
-from . import lang_config
+from . import lang_config, prompt_column, response_column
 
-_prompt = lang_config.prompt_column
-_response = lang_config.response_column
+_prompt = prompt_column
+_response = response_column
 
 _transformer_model = None
 _transformer_name = None

--- a/langkit/nlp_scores.py
+++ b/langkit/nlp_scores.py
@@ -1,6 +1,6 @@
 from whylogs.experimental.core.udf_schema import register_dataset_udf
 import evaluate
-from . import lang_config
+from . import lang_config, response_column
 from logging import getLogger
 
 
@@ -26,12 +26,12 @@ def _register_score_udfs():
                 _bleu_registered = True
 
                 @register_dataset_udf(
-                    [lang_config.response_column],
-                    udf_name=f"{lang_config.response_column}.bleu_score",
+                    [response_column],
+                    udf_name=f"{response_column}.bleu_score",
                 )
                 def bleu_score(text):
                     result = []
-                    for response in text[lang_config.response_column]:
+                    for response in text[response_column]:
                         result.append(
                             bleu.compute(predictions=[response], references=[_corpus])[
                                 "bleu"
@@ -44,12 +44,12 @@ def _register_score_udfs():
                 _rouge_registered = True
 
                 @register_dataset_udf(
-                    [lang_config.response_column],
-                    udf_name=f"{lang_config.response_column}.rouge_score",
+                    [response_column],
+                    udf_name=f"{response_column}.rouge_score",
                 )
                 def rouge_score(text):
                     result = []
-                    for response in text[lang_config.response_column]:
+                    for response in text[response_column]:
                         result.append(
                             rouge.compute(
                                 predictions=[text],
@@ -64,12 +64,12 @@ def _register_score_udfs():
                 _meteor_registered = True
 
                 @register_dataset_udf(
-                    [lang_config.response_column],
-                    udf_name=f"{lang_config.response_column}.meteor_score",
+                    [response_column],
+                    udf_name=f"{response_column}.meteor_score",
                 )
                 def meteor_score(text):
                     result = []
-                    for response in text[lang_config.response_column]:
+                    for response in text[response_column]:
                         result.append(
                             meteor.compute(predictions=[text], references=[_corpus])[
                                 "meteor"

--- a/langkit/nlp_scores.py
+++ b/langkit/nlp_scores.py
@@ -1,9 +1,9 @@
 from whylogs.experimental.core.udf_schema import register_dataset_udf
 import evaluate
-from . import LangKitConfig
+from . import lang_config
 from logging import getLogger
 
-lang_config = LangKitConfig()
+
 _corpus = lang_config.reference_corpus
 _scores = lang_config.nlp_scores
 _rouge_type = "rouge1"
@@ -11,11 +11,19 @@ _rouge_type = "rouge1"
 diagnostic_logger = getLogger(__name__)
 
 
-def register_score_udfs():
+_bleu_registered = False
+_rouge_registered = False
+_meteor_registered = False
+
+
+def _register_score_udfs():
+    global _bleu_registered, _rouge_registered, _meteor_registered
+
     if _corpus:
         for score in _scores:
-            if "bleu" in score:
+            if "bleu" in score and not _bleu_registered:
                 bleu = evaluate.load("bleu")
+                _bleu_registered = True
 
                 @register_dataset_udf(
                     [lang_config.response_column],
@@ -31,8 +39,9 @@ def register_score_udfs():
                         )
                     return result
 
-            if "rouge" in score:
+            if "rouge" in score and not _rouge_registered:
                 rouge = evaluate.load("rouge")
+                _rouge_registered = True
 
                 @register_dataset_udf(
                     [lang_config.response_column],
@@ -50,8 +59,9 @@ def register_score_udfs():
                         )
                     return result
 
-            if "meteor" in score:
+            if "meteor" in score and not _meteor_registered:
                 meteor = evaluate.load("meteor")
+                _meteor_registered = True
 
                 @register_dataset_udf(
                     [lang_config.response_column],
@@ -84,7 +94,7 @@ def init(corpus=None, scores=[], rouge_type=None):
     if rouge_type:
         _rouge_type = rouge_type
 
-    register_score_udfs()
+    _register_score_udfs()
 
 
 init()

--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -110,6 +110,6 @@ def init(
         pattern_loader.update_patterns()
 
     _register_udfs()
-    
+
 
 init()

--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -3,7 +3,7 @@ import re
 from logging import getLogger
 
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import LangKitConfig
+from . import LangKitConfig, lang_config
 from whylogs.core.metrics.metrics import FrequentItemsMetric
 from whylogs.core.resolvers import MetricSpec
 from whylogs.core.stubs import pd
@@ -13,8 +13,8 @@ diagnostic_logger = getLogger(__name__)
 
 
 class PatternLoader:
-    def __init__(self):
-        self.config: LangKitConfig = LangKitConfig()
+    def __init__(self, config: Optional[LangKitConfig] = None):
+        self.config = config or lang_config
         self.regex_groups = self.load_patterns()
 
     def load_patterns(self):
@@ -91,10 +91,13 @@ def init(
         pattern_loader.set_config(lang_config)
         pattern_loader.update_patterns()
 
-    if pattern_loader.get_regex_groups() is not None:
-        for column in [lang_config.prompt_column, lang_config.response_column]:
-            register_dataset_udf(
-                [column],
-                udf_name=f"{column}.has_patterns",
-                metrics=[MetricSpec(FrequentItemsMetric)],
-            )(has_patterns)
+
+init()
+
+if pattern_loader.get_regex_groups() is not None:
+    for column in [lang_config.prompt_column, lang_config.response_column]:
+        register_dataset_udf(
+            [column],
+            udf_name=f"{column}.has_patterns",
+            metrics=[MetricSpec(FrequentItemsMetric)],
+        )(has_patterns)

--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -3,7 +3,7 @@ import re
 from logging import getLogger
 
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import LangKitConfig, lang_config
+from . import LangKitConfig, lang_config, prompt_column, response_column
 from whylogs.core.metrics.metrics import FrequentItemsMetric
 from whylogs.core.resolvers import MetricSpec
 from whylogs.core.stubs import pd
@@ -88,7 +88,7 @@ def _register_udfs():
 
     if pattern_loader.get_regex_groups() is not None:
         _registered = True
-        for column in [lang_config.prompt_column, lang_config.response_column]:
+        for column in [prompt_column, response_column]:
             register_dataset_udf(
                 [column],
                 udf_name=f"{column}.has_patterns",
@@ -97,16 +97,15 @@ def _register_udfs():
 
 
 def init(
-    pattern_file_path: Optional[str] = None, lang_config: Optional[LangKitConfig] = None
+    pattern_file_path: Optional[str] = None, config: Optional[LangKitConfig] = None
 ):
-    if lang_config is None:
-        lang_config = LangKitConfig()
+    config = config or lang_config
     if pattern_file_path:
-        lang_config.pattern_file_path = pattern_file_path
-        pattern_loader.set_config(lang_config)
+        config.pattern_file_path = pattern_file_path
+        pattern_loader.set_config(config)
         pattern_loader.update_patterns()
     else:
-        pattern_loader.set_config(lang_config)
+        pattern_loader.set_config(config)
         pattern_loader.update_patterns()
 
     _register_udfs()

--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -86,8 +86,8 @@ def _register_udfs():
     if _registered:
         return
 
-    _registered = True
     if pattern_loader.get_regex_groups() is not None:
+        _registered = True
         for column in [lang_config.prompt_column, lang_config.response_column]:
             register_dataset_udf(
                 [column],

--- a/langkit/sentiment.py
+++ b/langkit/sentiment.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import lang_config
+from . import prompt_column, response_column
 
 
-_prompt = lang_config.prompt_column
-_response = lang_config.response_column
+_prompt = prompt_column
+_response = response_column
 _lexicon = "vader_lexicon"
 _sentiment_analyzer = None
 _nltk_downloaded = False

--- a/langkit/sentiment.py
+++ b/langkit/sentiment.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import LangKitConfig
+from . import lang_config
 
-lang_config = LangKitConfig()
+
 _prompt = lang_config.prompt_column
 _response = lang_config.response_column
 _lexicon = "vader_lexicon"

--- a/langkit/textstat.py
+++ b/langkit/textstat.py
@@ -66,6 +66,7 @@ _registered = False
 
 
 if not _registered:
+    _registered = True
     for t in _udfs_to_register:
         stat_name, schema_name, udf = _unpack(t)
         for column in [lang_config.prompt_column, lang_config.response_column]:

--- a/langkit/textstat.py
+++ b/langkit/textstat.py
@@ -3,9 +3,8 @@ from typing import Callable, Dict, List, Tuple, Union
 import textstat
 from whylogs.core.stubs import pd
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import LangKitConfig
+from . import lang_config
 
-lang_config = LangKitConfig()
 
 diagnostic_logger = getLogger(__name__)
 
@@ -53,17 +52,23 @@ def wrapper(
 
 
 def init():
-    diagnostic_logger.info("Initialized textstat metrics.")
-
-    def unpack(t: Union[Tuple[str, str], Tuple[str, str, str]]) -> Tuple[str, str, str]:
-        return t if len(t) == 3 else (t[0], t[1], t[0])  # type: ignore
-
-    for t in _udfs_to_register:
-        stat_name, schema_name, udf = unpack(t)
-        for column in [lang_config.prompt_column, lang_config.response_column]:
-            register_dataset_udf(
-                [column], udf_name=f"{column}.{udf}", schema_name=schema_name
-            )(wrapper(stat_name, column))
+    pass
 
 
 init()
+
+
+def _unpack(t: Union[Tuple[str, str], Tuple[str, str, str]]) -> Tuple[str, str, str]:
+    return t if len(t) == 3 else (t[0], t[1], t[0])  # type: ignore
+
+
+for t in _udfs_to_register:
+    stat_name, schema_name, udf = _unpack(t)
+    for column in [lang_config.prompt_column, lang_config.response_column]:
+        register_dataset_udf(
+            [column], udf_name=f"{column}.{udf}", schema_name=schema_name
+        )(wrapper(stat_name, column))
+
+diagnostic_logger.info("Initialized textstat metrics.")
+
+

--- a/langkit/textstat.py
+++ b/langkit/textstat.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict, List, Tuple, Union
 import textstat
 from whylogs.core.stubs import pd
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import lang_config
+from . import prompt_column, response_column
 
 
 diagnostic_logger = getLogger(__name__)
@@ -69,7 +69,7 @@ if not _registered:
     _registered = True
     for t in _udfs_to_register:
         stat_name, schema_name, udf = _unpack(t)
-        for column in [lang_config.prompt_column, lang_config.response_column]:
+        for column in [prompt_column, response_column]:
             register_dataset_udf(
                 [column], udf_name=f"{column}.{udf}", schema_name=schema_name
             )(wrapper(stat_name, column))

--- a/langkit/textstat.py
+++ b/langkit/textstat.py
@@ -70,5 +70,3 @@ for t in _udfs_to_register:
         )(wrapper(stat_name, column))
 
 diagnostic_logger.info("Initialized textstat metrics.")
-
-

--- a/langkit/textstat.py
+++ b/langkit/textstat.py
@@ -62,11 +62,15 @@ def _unpack(t: Union[Tuple[str, str], Tuple[str, str, str]]) -> Tuple[str, str, 
     return t if len(t) == 3 else (t[0], t[1], t[0])  # type: ignore
 
 
-for t in _udfs_to_register:
-    stat_name, schema_name, udf = _unpack(t)
-    for column in [lang_config.prompt_column, lang_config.response_column]:
-        register_dataset_udf(
-            [column], udf_name=f"{column}.{udf}", schema_name=schema_name
-        )(wrapper(stat_name, column))
+_registered = False
 
-diagnostic_logger.info("Initialized textstat metrics.")
+
+if not _registered:
+    for t in _udfs_to_register:
+        stat_name, schema_name, udf = _unpack(t)
+        for column in [lang_config.prompt_column, lang_config.response_column]:
+            register_dataset_udf(
+                [column], udf_name=f"{column}.{udf}", schema_name=schema_name
+            )(wrapper(stat_name, column))
+
+    diagnostic_logger.info("Initialized textstat metrics.")

--- a/langkit/themes.py
+++ b/langkit/themes.py
@@ -8,14 +8,14 @@ from whylogs.experimental.core.udf_schema import register_dataset_udf
 
 from langkit.transformer import load_model
 
-from . import lang_config
+from . import lang_config, prompt_column, response_column
 
 diagnostic_logger = getLogger(__name__)
 
 _transformer_model = None
 _theme_groups = None
-_prompt = lang_config.prompt_column
-_response = lang_config.response_column
+_prompt = prompt_column
+_response = response_column
 
 _embeddings_map: Dict[str, List] = {}
 

--- a/langkit/topics.py
+++ b/langkit/topics.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from transformers import (
     pipeline,
 )
-from . import lang_config
+from . import lang_config, prompt_column, response_column
 
 
 _topics = lang_config.topics
@@ -26,7 +26,7 @@ def init(topics: Optional[List] = None):
     global _topics
     if topics:
         _topics = topics
-    for column in [lang_config.prompt_column, lang_config.response_column]:
+    for column in [prompt_column, response_column]:
         register_dataset_udf([column], udf_name=f"{column}.closest_topic")(
             closest_topic
         )

--- a/langkit/topics.py
+++ b/langkit/topics.py
@@ -4,9 +4,9 @@ from typing import List, Optional
 from transformers import (
     pipeline,
 )
-from . import LangKitConfig
+from . import lang_config
 
-lang_config = LangKitConfig()
+
 _topics = lang_config.topics
 
 model_path = "MoritzLaurer/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7"

--- a/langkit/toxicity.py
+++ b/langkit/toxicity.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import LangKitConfig
+from . import lang_config
 
-lang_config = LangKitConfig()
+
 _prompt = lang_config.prompt_column
 _response = lang_config.response_column
 

--- a/langkit/toxicity.py
+++ b/langkit/toxicity.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-from . import lang_config
+from . import prompt_column, response_column
 
 
-_prompt = lang_config.prompt_column
-_response = lang_config.response_column
+_prompt = prompt_column
+_response = response_column
 
 _toxicity_model_path = "martin-ha/toxic-comment-model"
 _toxicity_tokenizer = None


### PR DESCRIPTION
- All modules can be reinitialized without multiple UDF registration
- All modules share a global `LangKitConfig` instance
- The registrations respect the config object settings when modified before importing the module
- You can't change the prompt/response column names registered after import
- All modules `init()` on import
- Cleans up most of the spurious warnings logged during the tests

Note that we'll need to update the custom metric tutorial if we merge this.