### PR TITLE
Allow custom embeddings encoder for input_output and themes

### DIFF
--- a/langkit/examples/Custom_Encoder.ipynb
+++ b/langkit/examples/Custom_Encoder.ipynb
@@ -1,0 +1,209 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DaXDovdJVMDo"
+      },
+      "source": [
+        "# Embeddings Encoder Customization\n",
+        "\n",
+        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/whylabs/langkit/blob/main/langkit/examples/Custom_Encoder.ipynb)\n",
+        "\n",
+        "Some modules in LangKit, such as the __themes__ and __input_output__ module, use an encoder to convert text into embeddings. In this example, we will show how you can plug in your own encoder to LangKit.\n",
+        "\n",
+        "## Default Behavior\n",
+        "\n",
+        "Let's use the themes module to talk about the default behavior. If you simply import the module without additional configuration, the default encoder will be used, which is the `all-MiniLM-L6-v2` model from the [Sentence Transformers](https://www.sbert.net/) library.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3rLjVWGhVMDq"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install -U langkit[all]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "uFBm39ZZVMDq",
+        "outputId": "ef4a6571-aa2c-4c43-ffbf-fbc52710280a"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "The similarity score with default encoder is:  0.9245336055755615\n"
+          ]
+        }
+      ],
+      "source": [
+        "from langkit import themes\n",
+        "\n",
+        "similarity_score = themes.group_similarity(\"Sorry, but I can't assist you with that.\", \"refusal\")\n",
+        "\n",
+        "print(\"The similarity score with default encoder is: \", similarity_score)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ra5QuSbMVMDr"
+      },
+      "source": [
+        "## Custom Encoder\n",
+        "\n",
+        "You can also pass your own encoder function to be used by LangKit. Let's define a simple function that takes a list of strings and returns a list of embeddings, one for each input string. Then, we pass that function to the `themes` initializer as the `custom_encoder` parameter."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "ltsMHWQhVMDr"
+      },
+      "outputs": [],
+      "source": [
+        "from typing import List\n",
+        "def embed(texts: List[str]) -> List[List[float]]:\n",
+        "    return [[0.2,0.2] for _ in texts]\n",
+        "\n",
+        "themes.init(custom_encoder=embed)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NLo9HEosVMDr"
+      },
+      "source": [
+        "Now, if we run the similarity calculation again, we see that the score is near 1.0. That makes sense, considering the embedding for every string is the same, and the cosine similarity between the same vector is 1.0."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "YWRipJ3WVMDr",
+        "outputId": "a7471dd7-6e85-4194-b3b4-362d733002c4"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "The similarity score with the custom encoder is:  0.9999999403953552\n"
+          ]
+        }
+      ],
+      "source": [
+        "similarity_score = themes.group_similarity(\"Sorry, but I can't assist you with that.\", \"refusal\")\n",
+        "\n",
+        "print(\"The similarity score with the custom encoder is: \", similarity_score)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lmoY5TsBVMDr"
+      },
+      "source": [
+        "## Universal Sentence Encoder\n",
+        "\n",
+        "Let's show another example with a real encoder. We will Google's Universal Sentence Encoder to encode sentences into vectors. We will use the [TensorFlow Hub](https://www.tensorflow.org/hub) to download the model, and pass the embed function into Langkit, just as before.\n",
+        "\n",
+        "> If your local environment doesn't have the required dependencies to use `tensorflow_hub`, we recommend running this example on Colab by clicking the button on the top of this example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "9T4q0Yo_VMDr"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow_hub as hub\n",
+        "\n",
+        "# Load pre-trained universal sentence encoder model\n",
+        "use_embed = hub.load(\"https://tfhub.dev/google/universal-sentence-encoder/4\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "whrIj26IXtYf"
+      },
+      "source": [
+        "Let's use `input_output` as an example this time, which will calculate the similarity score between a pair of prompt and response."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "McnUncp6VMDs",
+        "outputId": "24223c7c-3667-4b10-9574-f01a52e474b4"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "The similarity score with the Universal Sentence Encoder is:  [0.08993375301361084]\n"
+          ]
+        }
+      ],
+      "source": [
+        "from langkit.input_output import init, prompt_response_similarity\n",
+        "\n",
+        "init(custom_encoder=use_embed)\n",
+        "\n",
+        "similarity_score = prompt_response_similarity({\"prompt\": [\"What is the capital of France?\"], \"response\": [\"Mitochondria is the powerhouse of the cell\"]})\n",
+        "\n",
+        "print(\"The similarity score with the Universal Sentence Encoder is: \", similarity_score)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "langkit-rNdo63Yk-py3.8",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.10"
+    },
+    "orig_nbformat": 4
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import Optional
+from typing import Callable, Optional
 
 from sentence_transformers import util
 from whylogs.experimental.core.udf_schema import register_dataset_udf
@@ -14,10 +14,21 @@ _transformer_name = None
 
 diagnostic_logger = getLogger(__name__)
 
+class CustomEncoder:
+    def __init__(self, encoder: Callable):
+        self.encode = encoder
 
-def init(transformer_name: Optional[str] = None):
+def init(transformer_name: Optional[str] = None, encoder: Optional[Callable] = None):
     global _transformer_model, _transformer_name
-    if transformer_name is None:
+    if transformer_name and encoder:
+        raise ValueError(
+            "Only one of transformer_name or encoder can be specified, not both."
+        )
+    if encoder:
+        _transformer_model = CustomEncoder(encoder)
+        return
+
+    if transformer_name is None and encoder is None:
         transformer_name = lang_config.transformer_name
     _transformer_model = load_model(transformer_name)
     _transformer_name = transformer_name
@@ -27,7 +38,7 @@ init()
 
 
 @register_dataset_udf(["prompt", "response"], "response.relevance_to_prompt")
-def similarity_MiniLM_L6_v2(text):
+def prompt_response_similarity(text):
     if _transformer_model is None:
         raise ValueError(
             "response.relevance_to_prompt must have a transformer model initialized before use."
@@ -36,8 +47,12 @@ def similarity_MiniLM_L6_v2(text):
     series_result = []
     for x, y in zip(text["prompt"], text["response"]):
         try:
-            embedding_1 = _transformer_model.encode(x, convert_to_tensor=True)
-            embedding_2 = _transformer_model.encode(y, convert_to_tensor=True)
+            if not isinstance(_transformer_model,CustomEncoder):
+                embedding_1 = _transformer_model.encode(x, convert_to_tensor=True)
+                embedding_2 = _transformer_model.encode(y, convert_to_tensor=True)
+            else:
+                embedding_1 = _transformer_model.encode(x)
+                embedding_2 = _transformer_model.encode(y)
             similarity = util.pytorch_cos_sim(embedding_1, embedding_2)
             series_result.append(similarity.item())
         except Exception as e:

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -3,40 +3,25 @@ from typing import Callable, Optional
 
 from sentence_transformers import util
 from whylogs.experimental.core.udf_schema import register_dataset_udf
-
-from langkit.transformer import load_model
-
 from . import LangKitConfig
 
-try:
-    import tensorflow as tf
-except ImportError:
-    tf = None
+from langkit.transformer import Encoder
 
 lang_config = LangKitConfig()
+
+
 _transformer_model = None
-_transformer_name = None
 
 diagnostic_logger = getLogger(__name__)
 
-class CustomEncoder:
-    def __init__(self, encoder: Callable):
-        self.encode = encoder
 
-def init(transformer_name: Optional[str] = None, encoder: Optional[Callable] = None):
-    global _transformer_model, _transformer_name
-    if transformer_name and encoder:
-        raise ValueError(
-            "Only one of transformer_name or encoder can be specified, not both."
-        )
-    if encoder:
-        _transformer_model = CustomEncoder(encoder)
-        return
-
-    if transformer_name is None and encoder is None:
+def init(
+    transformer_name: Optional[str] = None, custom_encoder: Optional[Callable] = None
+):
+    global _transformer_model
+    if transformer_name is None and custom_encoder is None:
         transformer_name = lang_config.transformer_name
-    _transformer_model = load_model(transformer_name)
-    _transformer_name = transformer_name
+    _transformer_model = Encoder(transformer_name, custom_encoder)
 
 
 init()
@@ -44,6 +29,8 @@ init()
 
 @register_dataset_udf(["prompt", "response"], "response.relevance_to_prompt")
 def prompt_response_similarity(text):
+    global _transformer_model
+
     if _transformer_model is None:
         raise ValueError(
             "response.relevance_to_prompt must have a transformer model initialized before use."
@@ -52,15 +39,8 @@ def prompt_response_similarity(text):
     series_result = []
     for x, y in zip(text["prompt"], text["response"]):
         try:
-            if not isinstance(_transformer_model,CustomEncoder):
-                embedding_1 = _transformer_model.encode([x], convert_to_tensor=True)
-                embedding_2 = _transformer_model.encode([y], convert_to_tensor=True)
-            else:
-                embedding_1 = _transformer_model.encode([x])
-                embedding_2 = _transformer_model.encode([y])
-            if tf and isinstance(embedding_1, tf.Tensor) and isinstance(embedding_2,tf.Tensor):
-                embedding_1 = embedding_1.numpy()
-                embedding_2 = embedding_2.numpy()
+            embedding_1 = _transformer_model.encode([x] if isinstance(x, str) else x)
+            embedding_2 = _transformer_model.encode([y] if isinstance(y, str) else y)
             similarity = util.pytorch_cos_sim(embedding_1, embedding_2)
             series_result.append(similarity.item())
         except Exception as e:

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -53,11 +53,11 @@ def prompt_response_similarity(text):
     for x, y in zip(text["prompt"], text["response"]):
         try:
             if not isinstance(_transformer_model,CustomEncoder):
-                embedding_1 = _transformer_model.encode(x, convert_to_tensor=True)
-                embedding_2 = _transformer_model.encode(y, convert_to_tensor=True)
+                embedding_1 = _transformer_model.encode([x], convert_to_tensor=True)
+                embedding_2 = _transformer_model.encode([y], convert_to_tensor=True)
             else:
-                embedding_1 = _transformer_model.encode(x)
-                embedding_2 = _transformer_model.encode(y)
+                embedding_1 = _transformer_model.encode([x])
+                embedding_2 = _transformer_model.encode([y])
             if tf and isinstance(embedding_1, tf.Tensor) and isinstance(embedding_2,tf.Tensor):
                 embedding_1 = embedding_1.numpy()
                 embedding_2 = embedding_2.numpy()

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -8,6 +8,11 @@ from langkit.transformer import load_model
 
 from . import LangKitConfig
 
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
+
 lang_config = LangKitConfig()
 _transformer_model = None
 _transformer_name = None
@@ -53,11 +58,14 @@ def prompt_response_similarity(text):
             else:
                 embedding_1 = _transformer_model.encode(x)
                 embedding_2 = _transformer_model.encode(y)
+            if tf and isinstance(embedding_1, tf.Tensor) and isinstance(embedding_2,tf.Tensor):
+                embedding_1 = embedding_1.numpy()
+                embedding_2 = embedding_2.numpy()
             similarity = util.pytorch_cos_sim(embedding_1, embedding_2)
             series_result.append(similarity.item())
         except Exception as e:
             diagnostic_logger.warning(
-                f"pandas {text} caused similarity_MiniLM_L6_v2 to encounter error: {e}"
+                f"prompt_response_similarity encountered error {e} for text: {text}"
             )
             series_result.append(None)
     return series_result

--- a/langkit/input_output.py
+++ b/langkit/input_output.py
@@ -10,8 +10,6 @@ _prompt = prompt_column
 _response = response_column
 
 
-
-
 _transformer_model = None
 
 diagnostic_logger = getLogger(__name__)

--- a/langkit/tests/test_input_output.py
+++ b/langkit/tests/test_input_output.py
@@ -33,7 +33,7 @@ def texty(d):
 
     return True
 
-
+@pytest.mark.load
 def test_init_call():
     from langkit import input_output
 
@@ -43,7 +43,7 @@ def test_init_call():
             custom_encoder=lambda x: [[0.2, 0.2] for _ in x],
         )
 
-
+@pytest.mark.load
 def test_custom_encoder():
     from langkit import input_output
 

--- a/langkit/tests/test_input_output.py
+++ b/langkit/tests/test_input_output.py
@@ -33,6 +33,7 @@ def texty(d):
 
     return True
 
+
 @pytest.mark.load
 def test_init_call():
     from langkit import input_output
@@ -42,6 +43,7 @@ def test_init_call():
             transformer_name="sentence-transformers/all-MiniLM-L6-v2",
             custom_encoder=lambda x: [[0.2, 0.2] for _ in x],
         )
+
 
 @pytest.mark.load
 def test_custom_encoder():

--- a/langkit/tests/test_input_output.py
+++ b/langkit/tests/test_input_output.py
@@ -2,6 +2,7 @@ import pytest
 import whylogs as why
 from whylogs.core.metrics import MetricConfig
 from whylogs.experimental.core.udf_schema import udf_schema
+from typing import List
 
 
 @pytest.fixture
@@ -33,11 +34,43 @@ def texty(d):
     return True
 
 
+def test_init_call():
+    from langkit import input_output
+
+    with pytest.raises(ValueError):
+        input_output.init(
+            transformer_name="sentence-transformers/all-MiniLM-L6-v2",
+            custom_encoder=lambda x: [[0.2, 0.2] for _ in x],
+        )
+
+
+def test_custom_encoder():
+    from langkit import input_output
+
+    def embed(texts: List[str]):
+        return [[0.2, 0.2] for _ in texts]
+
+    interaction = {
+        "prompt": "What?",
+        "response": "blue",
+    }
+    input_output.init(custom_encoder=embed)
+    schema = udf_schema()
+    result = why.log(interaction, schema=schema)
+    dist_metric = (
+        result.view()
+        .get_column("response.relevance_to_prompt")
+        .get_metric("distribution")
+    )
+    assert dist_metric.to_summary_dict()["mean"] == pytest.approx(1.0)
+
+
 @pytest.mark.load
 def test_similarity(interactions):
     # default input col is "prompt" and output col is "response".
     from langkit import input_output as lkio  # noqa
 
+    lkio.init()
     schema = udf_schema(default_config=MetricConfig(fi_disabled=True))
     for i, interaction in enumerate(interactions):
         result = why.log(interaction, schema=schema)

--- a/langkit/tests/test_themes.py
+++ b/langkit/tests/test_themes.py
@@ -23,7 +23,7 @@ def interactions():
     ]
     return interactions_list
 
-
+@pytest.mark.load
 def test_init_call():
     from langkit import themes
 
@@ -33,7 +33,7 @@ def test_init_call():
             custom_encoder=lambda x: [[0.2, 0.2] for _ in x],
         )
 
-
+@pytest.mark.load
 def test_theme_custom(interactions):
     from langkit import themes
 

--- a/langkit/tests/test_themes.py
+++ b/langkit/tests/test_themes.py
@@ -23,6 +23,7 @@ def interactions():
     ]
     return interactions_list
 
+
 @pytest.mark.load
 def test_init_call():
     from langkit import themes
@@ -32,6 +33,7 @@ def test_init_call():
             transformer_name="sentence-transformers/all-MiniLM-L6-v2",
             custom_encoder=lambda x: [[0.2, 0.2] for _ in x],
         )
+
 
 @pytest.mark.load
 def test_theme_custom(interactions):

--- a/langkit/themes.py
+++ b/langkit/themes.py
@@ -1,12 +1,12 @@
 import json
 from logging import getLogger
-from typing import Optional, Dict, List
+from typing import Callable, Optional, Dict, List
 
 from sentence_transformers import util
 from torch import Tensor
 from whylogs.experimental.core.udf_schema import register_dataset_udf
 
-from langkit.transformer import load_model
+from langkit.transformer import Encoder
 
 from . import LangKitConfig
 
@@ -37,7 +37,7 @@ def group_similarity(text: str, group):
     if _transformer_model is None:
         raise ValueError("Must initialize a transformer before calling encode!")
 
-    text_embedding = _transformer_model.encode(text, convert_to_tensor=True)
+    text_embedding = _transformer_model.encode(text)
     for embedding in _embeddings_map.get(group, []):
         similarity = get_embeddings_similarity(text_embedding, embedding)
         similarities.append(similarity)
@@ -48,8 +48,7 @@ def _map_embeddings():
     global _embeddings_map
     for group in _theme_groups:
         _embeddings_map[group] = [
-            _transformer_model.encode(s, convert_to_tensor=True)
-            for s in _theme_groups.get(group, [])
+            _transformer_model.encode(s) for s in _theme_groups.get(group, [])
         ]
 
 
@@ -85,13 +84,15 @@ def load_themes(json_path: str, encoding="utf-8"):
 
 def init(
     transformer_name: Optional[str] = None,
+    custom_encoder: Optional[Callable] = None,
     theme_file_path: Optional[str] = None,
     theme_json: Optional[str] = None,
 ):
     global _transformer_model
     global _theme_groups
-    if transformer_name is None:
+    if not transformer_name and not custom_encoder:
         transformer_name = lang_config.transformer_name
+    _transformer_model = Encoder(transformer_name, custom_encoder)
     if theme_file_path is not None and theme_json is not None:
         raise ValueError("Cannot specify both theme_file_path and theme_json")
     if theme_file_path is None:
@@ -101,16 +102,13 @@ def init(
             _theme_groups = load_themes(lang_config.theme_file_path)
     else:
         _theme_groups = load_themes(theme_file_path)
-
-    _transformer_model = load_model(transformer_name)
-
     register_theme_udfs()
 
 
 def get_subject_similarity(text: str, comparison_embedding: Tensor) -> float:
     if _transformer_model is None:
         raise ValueError("Must initialize a transformer before calling encode!")
-    embedding = _transformer_model.encode(text, convert_to_tensor=True)
+    embedding = _transformer_model.encode(text)
     similarity = util.pytorch_cos_sim(embedding, comparison_embedding)
     return similarity.item()
 

--- a/langkit/themes.py
+++ b/langkit/themes.py
@@ -110,6 +110,7 @@ def init(
         _theme_groups = load_themes(theme_file_path)
     _register_theme_udfs()
 
+
 def get_subject_similarity(text: str, comparison_embedding: Tensor) -> float:
     if _transformer_model is None:
         raise ValueError("Must initialize a transformer before calling encode!")

--- a/langkit/transformer.py
+++ b/langkit/transformer.py
@@ -1,5 +1,5 @@
 from sentence_transformers import SentenceTransformer
-from typing import Optional, Callable, Union, List
+from typing import Optional, Callable, Union, List, Any
 from torch import Tensor
 import numpy as np
 
@@ -7,7 +7,6 @@ try:
     import tensorflow as tf
 except ImportError:
     tf = None
-    tf.Tensor = None
 
 
 class CustomEncoder:
@@ -19,9 +18,7 @@ class Encoder:
     def __init__(
         self,
         transformer_name: Optional[str],
-        custom_encoder: Optional[
-            Callable[[List[str]], Union[List, Tensor, np.ndarray, tf.Tensor]]
-        ],
+        custom_encoder: Optional[Callable[[List[str]], Any]],
     ):
         """
         Args:

--- a/langkit/transformer.py
+++ b/langkit/transformer.py
@@ -1,5 +1,64 @@
 from sentence_transformers import SentenceTransformer
+from typing import Optional, Callable, Union, List
+from torch import Tensor
+import numpy as np
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
 
 
-def load_model(transformer_name: str):
-    return SentenceTransformer(transformer_name)
+class CustomEncoder:
+    def __init__(self, encoder: Callable):
+        self.encode = encoder
+
+
+class Encoder:
+    def __init__(
+        self, transformer_name: Optional[str], custom_encoder: Optional[Callable]
+    ):
+        """
+        Args:
+            transformer_name: The name of the transformer model to use. If None, a custom encoder must be provided.
+                The name is expected to be a model name from the sentence_transformers library.
+            custom_encoder: A custom encoder to use. If None, a transformer model must be provided.
+                The custom encoder must be a callable that takes a list of strings and returns a list of embeddings.
+        """
+        if transformer_name and custom_encoder:
+            raise ValueError(
+                "Only one of transformer_name or encoder can be specified, not both."
+            )
+        if transformer_name is None and custom_encoder is None:
+            raise ValueError(
+                "One of transformer_name or encoder must be specified, none was given."
+            )
+        if custom_encoder:
+            transformer_model = CustomEncoder(custom_encoder)
+            self.transformer_name = "custom_encoder"
+        if transformer_name:
+            transformer_model = SentenceTransformer(transformer_name)
+            self.transformer_name = transformer_name
+        self.transformer_model = transformer_model
+
+    def encode(self, sentences: Union[List, str]) -> Union[Tensor, np.ndarray, List]:
+        """
+        Args:
+            sentences: A list of sentences to encode. If a string is given, it is converted to a list with one element.
+        Returns:
+            A list of embeddings, one for each sentence in the input. The embeddings can be either a Tensor, a numpy array or a list.
+            If the custom encoder returns a tensorflow tensor, it gets converted to a numpy array.
+        """
+        if isinstance(sentences, str):
+            sentences = [sentences]
+        if isinstance(self.transformer_model, SentenceTransformer):
+            embeddings = self.transformer_model.encode(
+                sentences, convert_to_tensor=True
+            )
+        elif isinstance(self.transformer_model, CustomEncoder):
+            embeddings = self.transformer_model.encode(sentences)
+        else:
+            raise ValueError("Unknown encoder model type")
+        if tf and isinstance(embeddings, tf.Tensor):
+            embeddings = embeddings.numpy()
+        return embeddings

--- a/langkit/transformer.py
+++ b/langkit/transformer.py
@@ -7,6 +7,7 @@ try:
     import tensorflow as tf
 except ImportError:
     tf = None
+    tf.Tensor = None
 
 
 class CustomEncoder:
@@ -16,7 +17,11 @@ class CustomEncoder:
 
 class Encoder:
     def __init__(
-        self, transformer_name: Optional[str], custom_encoder: Optional[Callable]
+        self,
+        transformer_name: Optional[str],
+        custom_encoder: Optional[
+            Callable[[List[str]], Union[List, Tensor, np.ndarray, tf.Tensor]]
+        ],
     ):
         """
         Args:


### PR DESCRIPTION
This PR enables the user to pass a Callable as custom encoder for `input_output` and `themes`.

- If the output of the embed function is a tensorflow Tensor, it is converted to numpy first to calculate the cosine similarity

```python
import tensorflow_hub as hub
from langkit.input_output import init, prompt_response_similarity

# Load pre-trained universal sentence encoder model
embed = hub.load("https://tfhub.dev/google/universal-sentence-encoder/4")


init(encoder=embed)

res = prompt_response_similarity({"prompt": ["Hi!"], "response": ["How are you?"]})

```

or

```python
import tensorflow_hub as hub
from langkit import input_output
from whylogs.experimental.core.udf_schema import udf_schema


# Load pre-trained universal sentence encoder model
embed = hub.load("https://tfhub.dev/google/universal-sentence-encoder/4")


input_output.init(encoder=embed)
text_schema = udf_schema()

res = prompt_response_similarity({"prompt": ["Hi!"], "response": ["How are you?"]})
profile = why.log({"prompt":"hi there!!!","response":"Sorry, but I can't assist with that"}, schema=text_schema).view()

```