### PR TITLE
Simplify create pull-request-action workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.14
+current_version = 0.0.15
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize =

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -68,18 +68,11 @@ jobs:
         run: poetry run bump2version patch --verbose --allow-dirty --no-tag --new-version ${{ env.VERSION }}
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4.1.1
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.VERSION_UPDATE }}
           commit-message: Update version to ${{ env.VERSION }}
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          signoff: false
           branch: update_release_version_${{ env.VERSION }}
           base: main
           delete-branch: true
           title: "Bump version to ${{ env.VERSION }}"
-
-          labels: |
-            automated pr
-          draft: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langkit"
-version = "0.0.14"
+version = "0.0.15"
 description = "A collection of text metric udfs for whylogs profiling and monitoring in WhyLabs"
 authors = ["WhyLabs.ai <langkit@whylabs.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
* Update version to 0.0.15
* Remove config values not needed in the create-pull-request action
* Update the action to v5

This PR is required after the last release workflow step to create the version bump PR failed with a permission error. This does not address the error but will help simplify the configuration and get the repo using the latest version of the action.