### PR TITLE
make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,25 @@
-.PHONY: install test load-test pre-commit
+.PHONY: default dist install test load-test pre-commit clean release
 
+
+dist:
+	poetry build
 
 install:
 	poetry install -E all
 
+clean:
+	rm -rf ./dist/langkit*.whl
+	rm -rf ./dist/langkit*.tar.gz
+
 test:
-	poetry run pytest langkit/tests
+	poetry run pytest langkit/tests -o log_level=INFO -o log_cli=true
 
 load-test:
-	poetry run pytest langkit/tests -o log_level=INFO -o log_cli=true --load
+	poetry run pytest langkit/tests --load
 
 pre-commit:
 	poetry run pre-commit run --all-files
+
+default: dist
+
+release: clean dist install load-test


### PR DESCRIPTION
Add some convenience make targets and tweaks:
* make dist clean build release
* update make test to output cli at INFO level
* make load-tests less spammy, current error logging is too long, need to address before we have info level debug output for load tests.