### PR TITLE
Quieter logs in LanKit test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ clean:
 	rm -rf ./dist/langkit*.tar.gz
 
 test:
-	poetry run pytest langkit/tests -o log_level=INFO -o log_cli=true
+	poetry run pytest langkit/tests -o log_level=WARN -o log_cli=true
 
 load-test:
-	poetry run pytest langkit/tests --load
+	poetry run pytest langkit/tests -o log_level=WARN -o log_cli=true --load
 
 pre-commit:
 	poetry run pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 	rm -rf ./dist/langkit*.tar.gz
 
 test:
-	poetry run pytest langkit/tests -o log_level=WARN -o log_cli=true
+	poetry run pytest langkit/tests -o log_level=INFO -o log_cli=true
 
 load-test:
 	poetry run pytest langkit/tests -o log_level=WARN -o log_cli=true --load

--- a/langkit/nlp_scores.py
+++ b/langkit/nlp_scores.py
@@ -78,7 +78,7 @@ def _register_score_udfs():
                     return result
 
     else:
-        diagnostic_logger.warning(
+        diagnostic_logger.info(
             "No reference corpus provided for NLP scores. Skipping NLP scores."
         )
 

--- a/langkit/tests/test_input_output.py
+++ b/langkit/tests/test_input_output.py
@@ -71,6 +71,13 @@ def test_custom_encoder():
 def test_similarity(interactions):
     # default input col is "prompt" and output col is "response".
     from langkit import input_output as lkio  # noqa
+    from whylogs.experimental.core.udf_schema import logger as uslog
+
+    iolog = lkio.diagnostic_logger
+    old_uslevel = uslog.getEffectiveLevel()
+    old_iolevel = iolog.getEffectiveLevel()
+    uslog.setLevel("CRITICAL")  # intentionally feeding bad input, so be quiet about it
+    iolog.setLevel("CRITICAL")
 
     lkio.init()
     schema = udf_schema(default_config=MetricConfig(fi_disabled=True))
@@ -100,3 +107,6 @@ def test_similarity(interactions):
             )
         else:
             assert column_name not in result.view().get_columns()
+
+    iolog.setLevel(old_iolevel)
+    uslog.setLevel(old_uslevel)


### PR DESCRIPTION
Increase log level around tests with intentional bad inputs. Change logging level to info instead of warn for normal input/output module init.