### PR TITLE
rolling logger in safeguards example from 30 min to 5 min

### DIFF
--- a/langkit/examples/tutorials/Safeguarding_and_Monitoring_LLMs.ipynb
+++ b/langkit/examples/tutorials/Safeguarding_and_Monitoring_LLMs.ipynb
@@ -298,7 +298,7 @@
    "source": [
     "## Observability and Monitoring\n",
     "\n",
-    "In this example, the rolling logger is configured to generate profiles and send them to WhyLabs every thirty minutes. If you wish to run the code by yourself, just remember to create your free account at https://whylabs.ai/free. You’ll need to get the API token, Organization ID and Dataset ID and input them in the example notebook.\n",
+    "In this example, the rolling logger is configured to generate profiles and send them to WhyLabs every five minutes. If you wish to run the code by yourself, just remember to create your free account at https://whylabs.ai/free. You’ll need to get the API token, Organization ID and Dataset ID and input them in the example notebook.\n",
     "\n",
     "In your monitoring dashboard, you’ll be able to see the evolution of your profiles over time and inspect all the metrics collected by LangKit, such as text readability, topic detection, semantic similarity, and more. Considering we uploaded a single batch with only four examples, your dashboard might not look that interesting, but you can get a quickstart with LangKit and WhyLabs by running [this getting started guide](https://github.com/whylabs/langkit/blob/main/langkit/examples/Intro_to_Langkit.ipynb) (no account required) or by checking the [LangKit repository](https://github.com/whylabs/langkit/tree/main).\n",
     "\n",

--- a/langkit/examples/tutorials/Safeguarding_and_Monitoring_LLMs_with_OpenAI.ipynb
+++ b/langkit/examples/tutorials/Safeguarding_and_Monitoring_LLMs_with_OpenAI.ipynb
@@ -164,7 +164,7 @@
     "\n",
     "__Logging__ - We will use whylogs to generate statistical profiles for the augmented columns. In the first stage (augmentation) a boolean `blocked` column was created. This column will be used to create segments, allowing us to visualize the metrics for blocked and non-blocked messages separately, in addition to the overall metrics.\n",
     "\n",
-    "__Monitoring__ - The logger will generate statistical profiles every 30 minutes and send them to WhyLabs for observability.\n",
+    "__Monitoring__ - The logger will generate statistical profiles every 5 minutes and send them to WhyLabs for observability.\n",
     "\n",
     "\\* The augmented columns are created internally, for whylogs use - your original data will not be modified. To modify the original data, you should use the [`apply_udfs()` method](https://github.com/whylabs/whylogs/blob/mainline/python/examples/experimental/whylogs_UDF_examples.ipynb)"
    ]
@@ -329,7 +329,7 @@
    "source": [
     "## Observability and Monitoring\n",
     "\n",
-    "In this example, the rolling logger is configured to generate profiles and send them to WhyLabs every thirty minutes. If you wish to run the code by yourself, just remember to create your free account at https://whylabs.ai/free. You’ll need to get the API token, Organization ID and Dataset ID and input them in the example notebook.\n",
+    "In this example, the rolling logger is configured to generate profiles and send them to WhyLabs every 5 minutes. If you wish to run the code by yourself, just remember to create your free account at https://whylabs.ai/free. You’ll need to get the API token, Organization ID and Dataset ID and input them in the example notebook.\n",
     "\n",
     "In your monitoring dashboard, you’ll be able to see the evolution of your profiles over time and inspect all the metrics collected by LangKit, such as text readability, topic detection, semantic similarity, and more. Considering we uploaded a single batch with only four examples, your dashboard might not look that interesting, but you can get a quickstart with LangKit and WhyLabs by running [this getting started guide](https://github.com/whylabs/langkit/blob/main/langkit/examples/Intro_to_Langkit.ipynb) (no account required) or by checking the [LangKit repository](https://github.com/whylabs/langkit/tree/main).\n",
     "\n",

--- a/langkit/whylogs/example_utils/guardrails_llm_schema.py
+++ b/langkit/whylogs/example_utils/guardrails_llm_schema.py
@@ -177,7 +177,7 @@ def validate_prompt(m_id):
 def get_llm_logger_with_validators(identity_column="m_id"):
     """
     This function returns a whylogs logger with validators for content moderation.
-    The logger will create profiles every 30 minutes and send them to WhyLabs for observability.
+    The logger will create profiles every 5 minutes and send them to WhyLabs for observability.
     Every logged prompt and response will be validated by the validators.
 
     Args:
@@ -216,7 +216,7 @@ def get_llm_logger_with_validators(identity_column="m_id"):
     )
 
     logger = why.logger(
-        mode="rolling", interval=30, when="M", base_name="langkit", schema=llm_schema
+        mode="rolling", interval=5, when="M", base_name="langkit", schema=llm_schema
     )
     logger.append_writer("whylabs")
 

--- a/langkit/whylogs/example_utils/guardrails_openai_example_llm_schema.py
+++ b/langkit/whylogs/example_utils/guardrails_openai_example_llm_schema.py
@@ -180,7 +180,7 @@ def validate_prompt(m_id):
 def get_llm_logger_with_validators(identity_column="m_id", toxicity_threshold=0.8):
     """
     This function returns a whylogs logger with validators for content moderation.
-    The logger will create profiles every 30 minutes and send them to WhyLabs for observability.
+    The logger will create profiles every 5 minutes and send them to WhyLabs for observability.
     Every logged prompt and response will be validated by the validators.
 
     Args:
@@ -223,7 +223,7 @@ def get_llm_logger_with_validators(identity_column="m_id", toxicity_threshold=0.
     )
 
     logger = why.logger(
-        mode="rolling", interval=30, when="M", base_name="langkit", schema=llm_schema
+        mode="rolling", interval=5, when="M", base_name="langkit", schema=llm_schema
     )
     logger.append_writer("whylabs")
 


### PR DESCRIPTION
Configuring a rolling logger with a period of 30 minutes can send profiles up until 30 mins into the future when closing the logger preemptively. For an hourly project, this can result in delays in data being displayed in the platform.