### PR TITLE
Add nltk.download of punkt to the response_hallucination init

### DIFF
--- a/langkit/response_hallucination.py
+++ b/langkit/response_hallucination.py
@@ -243,6 +243,9 @@ checker: Optional[ConsistencyCheker] = None
 
 def init(llm: LLMInvocationParams, num_samples=1):
     global checker
+    import nltk
+
+    nltk.download("punkt")
     diagnostic_logger.info(
         "Info: the response_hallucination metric module performs additionall LLM calls to check the consistency of the response."
     )


### PR DESCRIPTION
Fixes response_hallucination example by triggering the punkt download before using the new hallucination metric.

Verified in release testing against: https://colab.research.google.com/github/whylabs/LanguageToolkit/blob/main/langkit/examples/Response_Consistency.ipyn