### PR TITLE
Allow regexes UDF metric name to be configured in LangKitConfig

### DIFF
--- a/.github/workflows/langkit-ci.yml
+++ b/.github/workflows/langkit-ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure whylogs
         run: mkdir ~/.whylogs && echo \"\" >> ~/.whylogs/disable_telemetry
       - name: Run pre-commit checks
-        if: ${{ matrix.python-version == 3.8 }}
+        if: ${{ matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest' }}
         run: poetry run pre-commit run --all-files
       - name: Run build
         run: poetry build

--- a/langkit/__init__.py
+++ b/langkit/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import Dict, List
 
 import importlib.resources as resources
 
@@ -14,6 +14,7 @@ class LangKitConfig:
     pattern_file_path: str = field(
         default_factory=lambda: _resource_filename("pattern_groups.json")
     )
+    metric_name_map: Dict[str, str] = field(default_factory=dict)
     theme_file_path: str = field(
         default_factory=lambda: _resource_filename("themes.json")
     )

--- a/langkit/examples/Intro_to_Langkit.ipynb
+++ b/langkit/examples/Intro_to_Langkit.ipynb
@@ -58,7 +58,7 @@
     "from langkit import llm_metrics # alternatively use 'light_metrics'\n",
     "import whylogs as why\n",
     "\n",
-    "why.init(session_type='whylabs_anonymous')\n",
+    "why.init()\n",
     "# Note: llm_metrics.init() downloads models so this is slow first time.\n",
     "schema = llm_metrics.init()"
    ]

--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -41,7 +41,9 @@ _registered = False
 def _unregister_metric_udf(old_name: str, namespace: Optional[str] = ""):
     from whylogs.experimental.core.udf_schema import _multicolumn_udfs
 
-    global _multicolumn_udfs
+    if _multicolumn_udfs is None or namespace not in _multicolumn_udfs:
+        return
+
     _multicolumn_udfs[namespace] = [
         udf
         for udf in _multicolumn_udfs[namespace]

--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -38,17 +38,19 @@ def _wrapper(column):
 _registered = False
 
 
-def _register_udfs():
+def _register_udfs(config: Optional[LangKitConfig] = None):
     global _registered
-    if _registered:
+    if _registered and config is None:
         return
-
+    if config is None:
+        config = lang_config
+    pattern_metric_name = config.metric_name_map.get("has_patterns", "has_patterns")
     if pattern_loader.get_regex_groups() is not None:
         _registered = True
         for column in [prompt_column, response_column]:
             register_dataset_udf(
                 [column],
-                udf_name=f"{column}.has_patterns",
+                udf_name=f"{column}.{pattern_metric_name}",
                 metrics=[MetricSpec(FrequentItemsMetric)],
             )(_wrapper(column))
 
@@ -64,7 +66,7 @@ def init(
     pattern_loader = PatternLoader(config)
     pattern_loader.update_patterns()
 
-    _register_udfs()
+    _register_udfs(config)
 
 
 init()


### PR DESCRIPTION
Add a metric name mapping in LangKitConfig
Update regexes.py UDF to read the metric name mapping and default to "has_patterns"

Later we will update the other metrics to also support this kind of name mapping of the UDFs when registered to a column.

The mapping is left empty by design for now, but should give us some flexibility when we do some renaming with different configurations for different dashboards and use cases.

Example:
```python
from langkit import lang_config, llm_metrics

lang_config.metric_name_map["has_patterns"] = "data_leakage"
schema = llm_metrics.init(config=lang_config)
```

Note: this is not meant for direct end-user usage yet, the motivation here is to create some hooks for LangKit to be able to support multiple different sets of metric names as part of a config with presets (coming in later changes). Making the usability for multiple calls to init and clearing the UDFs already registered is a non-goal in this PR, and requires more coordinated changes with whylogs.

Addresses part of #174 and Fixes #159
Fixes #175 