### PR TITLE
Fix duplicate init ResolverSpec registration warning in has_patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ env.bak/
 venv.bak/
 pythonenv*
 .dockerignore
+langkit/langkit_data/
 
 # Spyder project settings
 .spyderproject

--- a/langkit/regexes.py
+++ b/langkit/regexes.py
@@ -6,7 +6,7 @@ from whylogs.experimental.core.udf_schema import register_dataset_udf
 from . import LangKitConfig, lang_config, prompt_column, response_column
 from whylogs.core.metrics.metrics import FrequentItemsMetric
 from whylogs.core.resolvers import MetricSpec
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 diagnostic_logger = getLogger(__name__)
 
@@ -52,6 +52,8 @@ def _unregister_metric_udf(old_name: str, namespace: Optional[str] = ""):
 
 
 def _register_udfs(config: Optional[LangKitConfig] = None):
+    from whylogs.experimental.core.udf_schema import _resolver_specs
+
     global _registered
     if _registered and config is None:
         return
@@ -61,8 +63,17 @@ def _register_udfs(config: Optional[LangKitConfig] = None):
     pattern_metric_name = config.metric_name_map.get(
         default_metric_name, default_metric_name
     )
+
     for old in _registered:
         _unregister_metric_udf(old_name=old)
+        if (
+            _resolver_specs is not None
+            and isinstance(_resolver_specs, Dict)
+            and isinstance(_resolver_specs[""], List)
+        ):
+            _resolver_specs[""] = [
+                spec for spec in _resolver_specs[""] if spec.column_name != old
+            ]
     _registered = []
 
     if pattern_loader.get_regex_groups() is not None:


### PR DESCRIPTION
There are some improvements pending in whylogs to make managing the UDF registrations easier in the scenarios we need to change them. This change checks for the old structure of the resolver specs, and then removes the duplicate UDFs similarly to how the old registrations are removed from the multicolumn_udfs

* Check for format, and then conditionally perform mitigation change to unregister old UDFs
* Incidental fix to add the injections langkit_data folder to .gitignore so that testing doesn't show up as a change

Tested against the Intro to LangKit notebook example.