### PR TITLE
better prompt for llm consistency check

### DIFF
--- a/langkit/response_hallucination.py
+++ b/langkit/response_hallucination.py
@@ -173,7 +173,7 @@ class ConsistencyChecker:
 
                 Don't include additional information/explanation. Please answer only with the options above.
 
-                Answer:                 
+                Answer:
                 """
                 result: ChatLog = Conversation(
                     self.consistency_checker_llm

--- a/langkit/response_hallucination.py
+++ b/langkit/response_hallucination.py
@@ -170,6 +170,10 @@ class ConsistencyChecker:
 
                 Is the passage supported by the context above?
                 Answer between: Accurate, Minor Inaccurate, Major Inaccurate
+
+                Don't include additional information/explanation. Please answer only with the options above.
+
+                Answer:                 
                 """
                 result: ChatLog = Conversation(
                     self.consistency_checker_llm


### PR DESCRIPTION
For some models, during the consistency check, the response would be one of the three categories with additional reasoning, which would throw off the score calculation. This change makes the instruction more explicit, stating the we only want the categories.