### PR TITLE
Add cache_assets hook to the metric api

### DIFF
--- a/.github/actions/python-build/action.yml
+++ b/.github/actions/python-build/action.yml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       run: make test
 
-    - name: Run test
+    - name: Make dists
       shell: bash
       run: make dist
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,3 +15,66 @@ jobs:
 
       - name: Python tests and build
         uses: ./.github/actions/python-build
+
+  enforce_cache_constraint:
+    name: Make sure the cache constraint logic works
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Maximize build space for large container build
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 8000
+          swap-size-mb: 2048
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+
+      - uses: actions/checkout@v3
+
+      - name: Setup /var/lib/docker
+        env:
+          MOUNT_PATH: ./docker-mount
+        shell: bash
+        run: |
+          # Starting state of docker dir
+          echo "Content of /var/lib/docker/"
+          sudo ls -lh /var/lib/docker/
+
+          # Stop docker first
+          sudo systemctl stop docker
+          sudo systemctl stop docker.socket
+          sudo systemctl stop containerd
+
+          mkdir -p $MOUNT_PATH/
+          touch $MOUNT_PATH/file # test to make sure its working. Should see this in /var/lib/docker now
+          sudo mount --bind ./docker-mount /var/lib/docker
+          sudo systemctl start docker
+
+          echo "Content of $MOUNT_PATH"
+          sudo ls -lh $MOUNT_PATH
+
+          echo "Content of /var/lib/docker/"
+          sudo ls -lh /var/lib/docker/
+
+          echo ""
+          findmnt
+
+      # Unclear what causes the permissions issue. Probably one of the disk space saving hacks.
+      - name: Fix permissions
+        run: |
+          ls -al .
+          sudo chown -R $USER:$USER .
+          sudo chmod -R a+r .
+          ls -al .
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run test
+        run: make test-cache-constraint

--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,7 @@ Thumbs.db
 [Ll]ib
 [Ll]ib64
 [Ll]ocal
-[Ss]cripts
+./[Ss]cripts
 pyvenv.cfg
 .venv
 pip-selfcheck.json

--- a/Dockerfile.cache_test
+++ b/Dockerfile.cache_test
@@ -1,0 +1,44 @@
+from python:3.10.13-slim 
+RUN groupadd -r whylabs && useradd --no-log-init -m -u 1000 -g whylabs whylabs 
+WORKDIR /opt/whylogs-container
+RUN chown -R whylabs:whylabs /opt/whylogs-container
+USER whylabs
+
+ENV LLM_CONTAINER=True
+ENV CONTAINER_CACHE_BASE=/opt/whylogs-container/.cache
+ENV HF_HOME=$CONTAINER_CACHE_BASE/hf_home/
+ENV NLTK_DATA=$CONTAINER_CACHE_BASE/nltk_data/
+ENV SENTENCE_TRANSFORMERS_HOME=$CONTAINER_CACHE_BASE/sentence_transformers/
+
+RUN mkdir -p $HF_HOME
+RUN mkdir -p $NLTK_DATA
+RUN mkdir -p $SENTENCE_TRANSFORMERS_HOME
+RUN chmod -R a+rw $CONTAINER_CACHE_BASE
+
+
+##
+## PYTHON DEPENDENCIES
+## Install/build pip dependencies
+##
+USER root
+RUN apt-get update && apt-get install -y curl build-essential
+USER whylabs
+# Install poetry
+ENV PATH="/home/whylabs/.local/bin:${PATH}"
+RUN python3.10 -m pip install --user pipx
+RUN python3.10 -m pipx ensurepath
+RUN python3.10 -m pipx install poetry==1.7.1
+
+COPY poetry.lock /opt/whylogs-container/
+COPY pyproject.toml /opt/whylogs-container/
+
+RUN poetry config virtualenvs.in-project true
+RUN poetry install --no-root --extras "all" --without dev
+RUN rm -rf .venv/lib/python3.10/site-packages/pandas/tests # Pandas deploys a ton of tests to pypi
+
+
+copy ./langkit ./langkit
+RUN bash -c "source .venv/bin/activate; python -m langkit.scripts.langkit_cache"
+# This step will fail if any network requests happen
+RUN --network=none bash -c "source .venv/bin/activate; python -m langkit.scripts.langkit_cache --skip-downloads"
+

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ clean:  ## Clean the project and generated files
 test:  ## Run the tests
 	poetry run pytest tests -o log_level=INFO -o log_cli=true
 
+test-cache-constraint:
+	docker build -f ./Dockerfile.cache_test . -t langkit_cache_test
+
 load-test:
 	poetry run pytest -vvv langkit/tests -o log_level=WARN -o log_cli=true --load
 

--- a/langkit/core/metric.py
+++ b/langkit/core/metric.py
@@ -87,6 +87,7 @@ class SingleMetric:
     input_name: str  # TODO the input_name isn't really used anywhere yet besides whylogs compat.
     evaluate: Callable[[pd.DataFrame], SingleMetricResult]
     init: Optional[Callable[[], None]] = None
+    cache_assets: Optional[Callable[[], None]] = None
 
 
 @dataclass(frozen=True)
@@ -97,6 +98,7 @@ class MultiMetric:
     input_name: str  # TODO this should be a list of input names so allow for things that have to consume both prompt/response
     evaluate: Callable[[pd.DataFrame], MultiMetricResult]
     init: Optional[Callable[[], None]] = None
+    cache_assets: Optional[Callable[[], None]] = None
 
 
 Metric = Union[SingleMetric, MultiMetric]

--- a/langkit/core/workflow.py
+++ b/langkit/core/workflow.py
@@ -69,11 +69,21 @@ class EvaluationWorkflow:
         callbacks: Optional[List[Callback]] = None,
         validators: Optional[List[Validator]] = None,
         lazy_init=False,
+        cache_assets=True,
     ) -> None:
+        """
+        Args:
+            metrics: A list of metrics to evaluate.
+            validators: A list of validators to run after the evaluation is complete.
+            callbacks: A list of callbacks to run after the evaluation is complete.
+            lazy_init: If True, the metrics will not be initialized until the first call to run.
+            cache_assets: If True, the assets required for the metrics will be cached during inititialization.
+        """
         self.hooks = callbacks or []
         self.metrics = EvaluationConfigBuilder().add(metrics).build()
         self.validators = validators or []
         self._initialized = False
+        self._cache_assets = cache_assets
 
         if not lazy_init:
             self.init()
@@ -87,6 +97,9 @@ class EvaluationWorkflow:
         # I prefer init just be idempotent but it might be hard for people to get right.
         metric_names: Set[str] = set()
         for metric in self.metrics.metrics:
+            if self._cache_assets and metric.cache_assets:
+                metric.cache_assets()
+
             if metric.init:
                 metric.init()
 

--- a/langkit/metrics/injections.py
+++ b/langkit/metrics/injections.py
@@ -68,7 +68,7 @@ def __load_embeddings() -> "np.ndarray[Any, Any]":
 
 
 def injections_metric(column_name: str) -> Metric:
-    def init():
+    def cache_assetes():
         sentence_transformer.value(__transformer_name)
         __embeddings.value
 
@@ -85,7 +85,7 @@ def injections_metric(column_name: str) -> Metric:
         metrics = [float(score) for _, score in zip(max_indices, max_similarities)]
         return SingleMetricResult(metrics=metrics)
 
-    return SingleMetric(name=f"{column_name}.injections", input_name=column_name, evaluate=udf, init=init)
+    return SingleMetric(name=f"{column_name}.injections", input_name=column_name, evaluate=udf, cache_assets=cache_assetes)
 
 
 prompt_injections_module = partial(injections_metric, "prompt")

--- a/langkit/metrics/input_output_similarity.py
+++ b/langkit/metrics/input_output_similarity.py
@@ -6,17 +6,22 @@ import pandas as pd
 from langkit.core.metric import Metric, SingleMetric, SingleMetricResult, UdfInput
 from langkit.metrics.embeddings_types import EmbeddingEncoder, TransformerEmbeddingAdapter
 from langkit.metrics.embeddings_utils import compute_embedding_similarity
+from langkit.metrics.util import DynamicLazyInit
 from langkit.transformer import sentence_transformer
+
+__default_transformer_name = "sentence-transformers/all-MiniLM-L6-v2"
+__transformer_embedding = DynamicLazyInit[str, TransformerEmbeddingAdapter](
+    lambda transformer_name: TransformerEmbeddingAdapter(sentence_transformer.value(transformer_name))
+)
 
 
 def input_output_similarity_metric(
     input_column_name: str = "prompt", output_column_name: str = "response", embedding_encoder: Optional[EmbeddingEncoder] = None
 ) -> Metric:
-    transformer_name = "sentence-transformers/all-MiniLM-L6-v2"
-    encoder = embedding_encoder or TransformerEmbeddingAdapter(sentence_transformer.value(transformer_name))
+    encoder = embedding_encoder or __transformer_embedding.value(__default_transformer_name)
 
-    def init():
-        sentence_transformer.value(transformer_name)
+    def cache_assets():
+        __transformer_embedding.value(__default_transformer_name)
 
     def udf(text: pd.DataFrame) -> SingleMetricResult:
         in_np = UdfInput(text).to_list(input_column_name)
@@ -32,7 +37,7 @@ def input_output_similarity_metric(
         name=f"{output_column_name}.relevance_to_{input_column_name}",
         input_name=input_column_name,
         evaluate=udf,
-        init=init,
+        cache_assets=cache_assets,
     )
 
 

--- a/langkit/metrics/sentiment_polarity.py
+++ b/langkit/metrics/sentiment_polarity.py
@@ -12,10 +12,12 @@ __analyzer = LazyInit(lambda: SentimentIntensityAnalyzer())
 
 
 def sentiment_polarity_metric(column_name: str, lexicon: str = "vader_lexicon") -> Metric:
-    def init():
+    def cache_assets():
         downloader = Downloader()
         if not downloader.is_installed(lexicon):  # pyright: ignore[reportUnknownMemberType]
             nltk.download(lexicon, raise_on_error=True)  # type: ignore[reportUnknownMemberType]
+
+    def init():
         __analyzer.value
 
     def udf(text: pd.DataFrame) -> SingleMetricResult:
@@ -27,6 +29,7 @@ def sentiment_polarity_metric(column_name: str, lexicon: str = "vader_lexicon") 
         input_name=column_name,
         evaluate=udf,
         init=init,
+        cache_assets=cache_assets,
     )
 
 

--- a/langkit/metrics/themes/themes.py
+++ b/langkit/metrics/themes/themes.py
@@ -76,9 +76,9 @@ def __themes_metric(
         text_list: List[str] = text[column_name].tolist()
         encoded_text = encoder.encode(text_list)  # (n_input_rows, embedding_dim)
         similarities = F.cosine_similarity(encoded_text.unsqueeze(1), theme.unsqueeze(0), dim=2)  # (n_input_rows, n_theme_examples)
-        max_similarities = similarities.max(dim=1)[0]  # (n_input_rows,)
-        similarity_list: List[float] = max_similarities.tolist()  # pyright: ignore[reportUnknownMemberType]
-        return SingleMetricResult(similarity_list)
+        max_similarities = similarities.max(dim=1)[0]  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]  (n_input_rows,)
+        similarity_list: List[float] = max_similarities.tolist()  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportUnknownVariableType]
+        return SingleMetricResult(similarity_list)  # pyright: ignore[reportUnknownArgumentType]
 
     return SingleMetric(
         name=f"{column_name}.{themes_group}_similarity",

--- a/langkit/metrics/topic.py
+++ b/langkit/metrics/topic.py
@@ -43,14 +43,14 @@ def topic_metric(column_name: str, topics: List[str]) -> Metric:
         metrics = [__get_closest_topic(it, topics) for it in UdfInput(text).iter_column_rows(column_name)]
         return SingleMetricResult(metrics)
 
-    def init():
+    def cache_assets():
         __classifier.value
 
     return SingleMetric(
         name=f"{column_name}.closest_topic",
         input_name=column_name,
         evaluate=udf,
-        init=init,
+        init=cache_assets,
     )
 
 

--- a/langkit/metrics/toxicity.py
+++ b/langkit/metrics/toxicity.py
@@ -36,7 +36,7 @@ __pipeline: DynamicLazyInit[str, TextClassificationPipeline] = DynamicLazyInit(
 
 
 def toxicity_metric(column_name: str, model_path="martin-ha/toxic-comment-model") -> Metric:
-    def init():
+    def cache_assets():
         __model.value(model_path)
         __tokenizer.value(model_path)
         __pipeline.value(model_path)
@@ -50,7 +50,7 @@ def toxicity_metric(column_name: str, model_path="martin-ha/toxic-comment-model"
         metrics = __toxicity(_pipeline, max_length, col)
         return SingleMetricResult(metrics=metrics)
 
-    return SingleMetric(name=f"{column_name}.toxicity", input_name=column_name, evaluate=udf, init=init)
+    return SingleMetric(name=f"{column_name}.toxicity", input_name=column_name, evaluate=udf, cache_assets=cache_assets)
 
 
 prompt_toxicity_module = partial(toxicity_metric, "prompt")

--- a/langkit/scripts/langkit_cache.py
+++ b/langkit/scripts/langkit_cache.py
@@ -1,0 +1,9 @@
+import sys
+
+from langkit.core.workflow import EvaluationWorkflow
+from langkit.metrics.library import lib
+
+if __name__ == "__main__":
+    wf = EvaluationWorkflow(metrics=[lib.all_metrics()], cache_assets="--skip-downloads" not in sys.argv)
+    # Run it to ensure nothing else ends up getting lazily cached
+    wf.run({"prompt": "How are you today?", "response": "I'm doing great!"})

--- a/poetry.lock
+++ b/poetry.lock
@@ -496,6 +496,35 @@ gs = ["google-cloud-storage"]
 s3 = ["boto3"]
 
 [[package]]
+name = "cmake"
+version = "3.28.3"
+description = "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
+optional = true
+python-versions = "*"
+files = [
+    {file = "cmake-3.28.3-py2.py3-none-macosx_10_10_universal2.macosx_10_10_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl", hash = "sha256:f27187ae016b089d1c1fca6a24b3af58f9d79471097eaa3b7a7a7623ad12ea89"},
+    {file = "cmake-3.28.3-py2.py3-none-manylinux2010_i686.manylinux_2_12_i686.whl", hash = "sha256:f5573c453f7a6c213c82741c173d174b5c6b576eea5cc00e2a8a5a30c40244b3"},
+    {file = "cmake-3.28.3-py2.py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:35b14086257dc7ce8e83c19d2d20f7953d584fa3c9d1904211d8498fe1134ecc"},
+    {file = "cmake-3.28.3-py2.py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:795c4c7f0ad16cc6553085502a76aa7fcf36fd2f4c8420542d1c7f3be6f9de1e"},
+    {file = "cmake-3.28.3-py2.py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2b811a7c97b2b31a56397baeb5ca93119fa4d215846851059748427c67f14a58"},
+    {file = "cmake-3.28.3-py2.py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8415ed1a9335eb30b0e435c38bcaeb8fd9ae900a9594fe500f3bcba744be1dc7"},
+    {file = "cmake-3.28.3-py2.py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2745d4362ac23f2f979e71d44759af740c3890429cb8a7e2fd449a30a901632f"},
+    {file = "cmake-3.28.3-py2.py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d3bc42bf54ea3d64e5d81eb31275076817507cf4a6aa07a49ffc01985cae1f09"},
+    {file = "cmake-3.28.3-py2.py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:de10be2f470c41a3628e27157168f017ade2f14065588497e00f4582bc5eec07"},
+    {file = "cmake-3.28.3-py2.py3-none-musllinux_1_1_i686.whl", hash = "sha256:5e4972e455fc24509561873cb06c9d9394852d77adde1cf970b859ad14a2a66f"},
+    {file = "cmake-3.28.3-py2.py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:ea338ae68e0c5626f7c21f89b765eb0e81f7b497e977503a3bcce569984dc8a7"},
+    {file = "cmake-3.28.3-py2.py3-none-musllinux_1_1_s390x.whl", hash = "sha256:c6415d382933854d2b5508c4d2218cfb1a8cb90f5f78b4e97183f80089868eea"},
+    {file = "cmake-3.28.3-py2.py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:cc67c5e5df8db0be57d25b81f7dc76e0ec79215f914e585a8045589a380bcd3c"},
+    {file = "cmake-3.28.3-py2.py3-none-win32.whl", hash = "sha256:29d127e5ef256d389feac0884e918612b89eb3a8febff1acf83bb27bc65042ab"},
+    {file = "cmake-3.28.3-py2.py3-none-win_amd64.whl", hash = "sha256:f6fc9755979d17970ca6d9688fb5cdd3702c9eaa7ac1ee97074e3d39d3400970"},
+    {file = "cmake-3.28.3-py2.py3-none-win_arm64.whl", hash = "sha256:4b1b413cf7683d54ec2a0f3b17a4d7c6979eb469270439c0e7a082256c78ab96"},
+    {file = "cmake-3.28.3.tar.gz", hash = "sha256:a8092815c739da7d6775c26ec30c2645f0fca9527a29e36a682faec7d39cde89"},
+]
+
+[package.extras]
+test = ["coverage (>=4.2)", "importlib-metadata (>=2.0)", "pytest (>=3.0.3)", "pytest-cov (>=2.4.0)"]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -1262,6 +1291,16 @@ files = [
 data = ["language-data (>=1.1,<2.0)"]
 
 [[package]]
+name = "lit"
+version = "17.0.6"
+description = "A Software Testing Tool"
+optional = true
+python-versions = "*"
+files = [
+    {file = "lit-17.0.6.tar.gz", hash = "sha256:dfa9af9b55fc4509a56be7bf2346f079d7f4a242d583b9f2e0b078fd0abae31b"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.4"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1515,6 +1554,17 @@ files = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = true
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 description = "Patch asyncio to allow nested event loops"
@@ -1617,147 +1667,6 @@ files = [
     {file = "numpy-1.24.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a"},
     {file = "numpy-1.24.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2"},
     {file = "numpy-1.24.4.tar.gz", hash = "sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463"},
-]
-
-[[package]]
-name = "nvidia-cublas-cu12"
-version = "12.1.3.1"
-description = "CUBLAS native runtime libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728"},
-    {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-win_amd64.whl", hash = "sha256:2b964d60e8cf11b5e1073d179d85fa340c120e99b3067558f3cf98dd69d02906"},
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.1.105"
-description = "CUDA profiling tools runtime libs."
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e"},
-    {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:bea8236d13a0ac7190bd2919c3e8e6ce1e402104276e6f9694479e48bb0eb2a4"},
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.1.105"
-description = "NVRTC native runtime libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2"},
-    {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:0a98a522d9ff138b96c010a65e145dc1b4850e9ecb75a0172371793752fd46ed"},
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.1.105"
-description = "CUDA Runtime native Libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40"},
-    {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:dfb46ef84d73fababab44cf03e3b83f80700d27ca300e537f85f636fac474344"},
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "8.9.2.26"
-description = "cuDNN runtime libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl", hash = "sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.0.2.54"
-description = "CUFFT native runtime libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl", hash = "sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56"},
-    {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-win_amd64.whl", hash = "sha256:d9ac353f78ff89951da4af698f80870b1534ed69993f10a4cf1d96f21357e253"},
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.2.106"
-description = "CURAND native runtime libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0"},
-    {file = "nvidia_curand_cu12-10.3.2.106-py3-none-win_amd64.whl", hash = "sha256:75b6b0c574c0037839121317e17fd01f8a69fd2ef8e25853d826fec30bdba74a"},
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.4.5.107"
-description = "CUDA solver native runtime libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd"},
-    {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-win_amd64.whl", hash = "sha256:74e0c3a24c78612192a74fcd90dd117f1cf21dea4822e66d89e8ea80e3cd2da5"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-nvidia-cusparse-cu12 = "*"
-nvidia-nvjitlink-cu12 = "*"
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.1.0.106"
-description = "CUSPARSE native runtime libraries"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c"},
-    {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-win_amd64.whl", hash = "sha256:b798237e81b9719373e8fae8d4f091b70a0cf09d9d85c95a557e11df2d8e9a5a"},
-]
-
-[package.dependencies]
-nvidia-nvjitlink-cu12 = "*"
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.19.3"
-description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_nccl_cu12-2.19.3-py3-none-manylinux1_x86_64.whl", hash = "sha256:a9734707a2c96443331c1e48c717024aa6678a0e2a4cb66b2c364d18cee6b48d"},
-]
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.3.101"
-description = "Nvidia JIT LTO Library"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_nvjitlink_cu12-12.3.101-py3-none-manylinux1_x86_64.whl", hash = "sha256:64335a8088e2b9d196ae8665430bc6a2b7e6ef2eb877a9c735c804bd4ff6467c"},
-    {file = "nvidia_nvjitlink_cu12-12.3.101-py3-none-win_amd64.whl", hash = "sha256:1b2e317e437433753530792f13eece58f0aec21a2b05903be7bffe58a606cbd1"},
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.1.105"
-description = "NVIDIA Tools Extension"
-optional = true
-python-versions = ">=3"
-files = [
-    {file = "nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5"},
-    {file = "nvidia_nvtx_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82"},
 ]
 
 [[package]]
@@ -2449,6 +2358,21 @@ files = [
 [package.extras]
 doc = ["sphinx", "sphinx_rtd_theme"]
 test = ["flake8", "isort", "pytest"]
+
+[[package]]
+name = "pyre-extensions"
+version = "0.0.29"
+description = "Type system extensions for use with the pyre type checker"
+optional = true
+python-versions = "*"
+files = [
+    {file = "pyre-extensions-0.0.29.tar.gz", hash = "sha256:4113600706c47306a156dcc9c405f4d458c505be432699571e357ef20e2d5d77"},
+    {file = "pyre_extensions-0.0.29-py3-none-any.whl", hash = "sha256:f4fef9089872c0656f82de7e8f357af0377dcbb6c2deadc1a7d3037aaf43757e"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+typing-inspect = "*"
 
 [[package]]
 name = "pyright"
@@ -3714,61 +3638,36 @@ files = [
 
 [[package]]
 name = "torch"
-version = "2.2.0"
+version = "2.0.0+cu118"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 optional = true
 python-versions = ">=3.8.0"
 files = [
-    {file = "torch-2.2.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:d366158d6503a3447e67f8c0ad1328d54e6c181d88572d688a625fac61b13a97"},
-    {file = "torch-2.2.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:707f2f80402981e9f90d0038d7d481678586251e6642a7a6ef67fc93511cb446"},
-    {file = "torch-2.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:15c8f0a105c66b28496092fca1520346082e734095f8eaf47b5786bac24b8a31"},
-    {file = "torch-2.2.0-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:0ca4df4b728515ad009b79f5107b00bcb2c63dc202d991412b9eb3b6a4f24349"},
-    {file = "torch-2.2.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:3d3eea2d5969b9a1c9401429ca79efc668120314d443d3463edc3289d7f003c7"},
-    {file = "torch-2.2.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:0d1c580e379c0d48f0f0a08ea28d8e373295aa254de4f9ad0631f9ed8bc04c24"},
-    {file = "torch-2.2.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9328e3c1ce628a281d2707526b4d1080eae7c4afab4f81cea75bde1f9441dc78"},
-    {file = "torch-2.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:03c8e660907ac1b8ee07f6d929c4e15cd95be2fb764368799cca02c725a212b8"},
-    {file = "torch-2.2.0-cp311-none-macosx_10_9_x86_64.whl", hash = "sha256:da0cefe7f84ece3e3b56c11c773b59d1cb2c0fd83ddf6b5f7f1fd1a987b15c3e"},
-    {file = "torch-2.2.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:f81d23227034221a4a4ff8ef24cc6cec7901edd98d9e64e32822778ff01be85e"},
-    {file = "torch-2.2.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:dcbfb2192ac41ca93c756ebe9e2af29df0a4c14ee0e7a0dd78f82c67a63d91d4"},
-    {file = "torch-2.2.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:9eeb42971619e24392c9088b5b6d387d896e267889d41d267b1fec334f5227c5"},
-    {file = "torch-2.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:c718b2ca69a6cac28baa36d86d8c0ec708b102cebd1ceb1b6488e404cd9be1d1"},
-    {file = "torch-2.2.0-cp312-none-macosx_10_9_x86_64.whl", hash = "sha256:f11d18fceb4f9ecb1ac680dde7c463c120ed29056225d75469c19637e9f98d12"},
-    {file = "torch-2.2.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:ee1da852bfd4a7e674135a446d6074c2da7194c1b08549e31eae0b3138c6b4d2"},
-    {file = "torch-2.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0d819399819d0862268ac531cf12a501c253007df4f9e6709ede8a0148f1a7b8"},
-    {file = "torch-2.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:08f53ccc38c49d839bc703ea1b20769cc8a429e0c4b20b56921a9f64949bf325"},
-    {file = "torch-2.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:93bffe3779965a71dab25fc29787538c37c5d54298fd2f2369e372b6fb137d41"},
-    {file = "torch-2.2.0-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:c17ec323da778efe8dad49d8fb534381479ca37af1bfc58efdbb8607a9d263a3"},
-    {file = "torch-2.2.0-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:c02685118008834e878f676f81eab3a952b7936fa31f474ef8a5ff4b5c78b36d"},
-    {file = "torch-2.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d9f39d6f53cec240a0e3baa82cb697593340f9d4554cee6d3d6ca07925c2fac0"},
-    {file = "torch-2.2.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:51770c065206250dc1222ea7c0eff3f88ab317d3e931cca2aee461b85fbc2472"},
-    {file = "torch-2.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:008e4c6ad703de55af760c73bf937ecdd61a109f9b08f2bbb9c17e7c7017f194"},
-    {file = "torch-2.2.0-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:de8680472dd14e316f42ceef2a18a301461a9058cd6e99a1f1b20f78f11412f1"},
-    {file = "torch-2.2.0-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:99e1dcecb488e3fd25bcaac56e48cdb3539842904bdc8588b0b255fde03a254c"},
+    {file = "torch-2.0.0+cu118-cp310-cp310-linux_x86_64.whl", hash = "sha256:4b690e2b77f21073500c65d8bb9ea9656b8cb4e969f357370bbc992a3b074764"},
+    {file = "torch-2.0.0+cu118-cp310-cp310-win_amd64.whl", hash = "sha256:5ee2b7c19265b9c869525c378fcdf350510b8f3fc08af26da1a2587a34cea8f5"},
+    {file = "torch-2.0.0+cu118-cp311-cp311-linux_x86_64.whl", hash = "sha256:238573d362c564113451046f6708c3b8158fe6b1b7f6c03b7273327d955deb54"},
+    {file = "torch-2.0.0+cu118-cp311-cp311-win_amd64.whl", hash = "sha256:dbba5b085722d24d617102954d9a9023ee4f7584148a9e465afb0c9696d15517"},
+    {file = "torch-2.0.0+cu118-cp38-cp38-linux_x86_64.whl", hash = "sha256:1f8efaebfcbb7ec3962fd8c7c3be02c6666eff53a12043006a749d647656163e"},
+    {file = "torch-2.0.0+cu118-cp38-cp38-win_amd64.whl", hash = "sha256:2588926725750c9ba799c133d4f6ee8fa477f6f0d88d6c2cebfe5bcfe8d7d7c3"},
+    {file = "torch-2.0.0+cu118-cp39-cp39-linux_x86_64.whl", hash = "sha256:eab97a9fe59e7e31d6562b186f435e717b1df3331cadc776e6c0732239a9ed39"},
+    {file = "torch-2.0.0+cu118-cp39-cp39-win_amd64.whl", hash = "sha256:893f6dd205316a104b04b69877bc40ab9908428274920094c17b81396a8c985c"},
 ]
 
 [package.dependencies]
 filelock = "*"
-fsspec = "*"
 jinja2 = "*"
 networkx = "*"
-nvidia-cublas-cu12 = {version = "12.1.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-cupti-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-nvrtc-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-runtime-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cudnn-cu12 = {version = "8.9.2.26", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cufft-cu12 = {version = "11.0.2.54", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-curand-cu12 = {version = "10.3.2.106", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusolver-cu12 = {version = "11.4.5.107", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusparse-cu12 = {version = "12.1.0.106", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nccl-cu12 = {version = "2.19.3", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nvtx-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 sympy = "*"
-triton = {version = "2.2.0", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-typing-extensions = ">=4.8.0"
+triton = {version = "2.0.0", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+typing-extensions = "*"
 
 [package.extras]
 opt-einsum = ["opt-einsum (>=3.3)"]
-optree = ["optree (>=0.9.1)"]
+
+[package.source]
+type = "legacy"
+url = "https://download.pytorch.org/whl/cu118"
+reference = "torch"
 
 [[package]]
 name = "tornado"
@@ -3895,26 +3794,40 @@ vision = ["Pillow (>=10.0.1,<=15.0)"]
 
 [[package]]
 name = "triton"
-version = "2.2.0"
+version = "2.0.0"
 description = "A language and compiler for custom Deep Learning operations"
 optional = true
 python-versions = "*"
 files = [
-    {file = "triton-2.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2294514340cfe4e8f4f9e5c66c702744c4a117d25e618bd08469d0bfed1e2e5"},
-    {file = "triton-2.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da58a152bddb62cafa9a857dd2bc1f886dbf9f9c90a2b5da82157cd2b34392b0"},
-    {file = "triton-2.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0af58716e721460a61886668b205963dc4d1e4ac20508cc3f623aef0d70283d5"},
-    {file = "triton-2.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8fe46d3ab94a8103e291bd44c741cc294b91d1d81c1a2888254cbf7ff846dab"},
-    {file = "triton-2.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8ce26093e539d727e7cf6f6f0d932b1ab0574dc02567e684377630d86723ace"},
-    {file = "triton-2.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:227cc6f357c5efcb357f3867ac2a8e7ecea2298cd4606a8ba1e931d1d5a947df"},
+    {file = "triton-2.0.0-1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:38806ee9663f4b0f7cd64790e96c579374089e58f49aac4a6608121aa55e2505"},
+    {file = "triton-2.0.0-1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:226941c7b8595219ddef59a1fdb821e8c744289a132415ddd584facedeb475b1"},
+    {file = "triton-2.0.0-1-cp36-cp36m-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4c9fc8c89874bc48eb7e7b2107a9b8d2c0bf139778637be5bfccb09191685cfd"},
+    {file = "triton-2.0.0-1-cp37-cp37m-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d2684b6a60b9f174f447f36f933e9a45f31db96cb723723ecd2dcfd1c57b778b"},
+    {file = "triton-2.0.0-1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9d4978298b74fcf59a75fe71e535c092b023088933b2f1df933ec32615e4beef"},
+    {file = "triton-2.0.0-1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:74f118c12b437fb2ca25e1a04759173b517582fcf4c7be11913316c764213656"},
+    {file = "triton-2.0.0-1-pp37-pypy37_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9618815a8da1d9157514f08f855d9e9ff92e329cd81c0305003eb9ec25cc5add"},
+    {file = "triton-2.0.0-1-pp38-pypy38_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1aca3303629cd3136375b82cb9921727f804e47ebee27b2677fef23005c3851a"},
+    {file = "triton-2.0.0-1-pp39-pypy39_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e3e13aa8b527c9b642e3a9defcc0fbd8ffbe1c80d8ac8c15a01692478dc64d8a"},
+    {file = "triton-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f05a7e64e4ca0565535e3d5d3405d7e49f9d308505bb7773d21fb26a4c008c2"},
+    {file = "triton-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb4b99ca3c6844066e516658541d876c28a5f6e3a852286bbc97ad57134827fd"},
+    {file = "triton-2.0.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47b4d70dc92fb40af553b4460492c31dc7d3a114a979ffb7a5cdedb7eb546c08"},
+    {file = "triton-2.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fedce6a381901b1547e0e7e1f2546e4f65dca6d91e2d8a7305a2d1f5551895be"},
+    {file = "triton-2.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75834f27926eab6c7f00ce73aaf1ab5bfb9bec6eb57ab7c0bfc0a23fac803b4c"},
+    {file = "triton-2.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0117722f8c2b579cd429e0bee80f7731ae05f63fe8e9414acd9a679885fcbf42"},
+    {file = "triton-2.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcd9be5d0c2e45d2b7e6ddc6da20112b6862d69741576f9c3dbaf941d745ecae"},
+    {file = "triton-2.0.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42a0d2c3fc2eab4ba71384f2e785fbfd47aa41ae05fa58bf12cb31dcbd0aeceb"},
+    {file = "triton-2.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52c47b72c72693198163ece9d90a721299e4fb3b8e24fd13141e384ad952724f"},
 ]
 
 [package.dependencies]
+cmake = "*"
 filelock = "*"
+lit = "*"
+torch = "*"
 
 [package.extras]
-build = ["cmake (>=3.20)", "lit"]
-tests = ["autopep8", "flake8", "isort", "numpy", "pytest", "scipy (>=1.7.1)", "torch"]
-tutorials = ["matplotlib", "pandas", "tabulate", "torch"]
+tests = ["autopep8", "flake8", "isort", "numpy", "pytest", "scipy (>=1.7.1)"]
+tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
 name = "typer"
@@ -3972,6 +3885,21 @@ files = [
     {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
     {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
 ]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+description = "Runtime inspection utilities for typing module."
+optional = true
+python-versions = "*"
+files = [
+    {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
+    {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "tzdata"
@@ -4154,25 +4082,23 @@ files = [
 
 [[package]]
 name = "xformers"
-version = "0.0.24"
+version = "0.0.19"
 description = "XFormers: A collection of composable Transformer building blocks."
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "xformers-0.0.24-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:018f928bd37b855021d12bff57797e729604474ccc2daa5504e1e4e4a5e6e3f7"},
-    {file = "xformers-0.0.24-cp310-cp310-win_amd64.whl", hash = "sha256:2ebacd38644e4df6a74e14fae55d561acd6d642b62819c1b8c10e07428efdad7"},
-    {file = "xformers-0.0.24-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:9c7e0c599bed5c7110f816b38083d13158c32b1e2e5a9fcb86a818112e5ba092"},
-    {file = "xformers-0.0.24-cp311-cp311-win_amd64.whl", hash = "sha256:7510268679d32475cb0f0c31d3f8b0a97ebfcd77fea2a1604516908eee0569bb"},
-    {file = "xformers-0.0.24-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:50e27d395905d2b95259f1c836207ae45b976d2f318c1099ca5e0edc41627abd"},
-    {file = "xformers-0.0.24-cp38-cp38-win_amd64.whl", hash = "sha256:dd7d65307373fcec77974775980ecd110fdc06489c4d18278a5a923afdd8dde1"},
-    {file = "xformers-0.0.24-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c9b3644551186f0e8bff4275813623ff051192b0f2469e7e5f25d56d38f359eb"},
-    {file = "xformers-0.0.24-cp39-cp39-win_amd64.whl", hash = "sha256:039f173608a37c1ff74dfd243671d0a12c9d507427f2b864373da838251fd374"},
-    {file = "xformers-0.0.24.tar.gz", hash = "sha256:1f87f48f6866adfea2f6b369d5556f39c6627357dbd54b9298c8516212c16cfe"},
+    {file = "xformers-0.0.19-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:a64fc7be47813e66cac278f7d5451db16243fa758973e90acce3649c63bbf771"},
+    {file = "xformers-0.0.19-cp310-cp310-win_amd64.whl", hash = "sha256:542d2d04f1bc42c11f22fd2360b52b737132a405a8572dde1e251082be477790"},
+    {file = "xformers-0.0.19-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:f5a874c4bf7831e55c691b8f133499db4ae489dfaa14c1af9674b929f59d4c79"},
+    {file = "xformers-0.0.19-cp38-cp38-win_amd64.whl", hash = "sha256:2fa58b84db175c9636d6b04d8278f1b4284b096e774b6ed7f449cf7949a3bc49"},
+    {file = "xformers-0.0.19-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ed352f4a09b30f72409c57248cf15728838967ec175e2befe8aaece6e90be456"},
+    {file = "xformers-0.0.19-cp39-cp39-win_amd64.whl", hash = "sha256:8f86c18ff582d7aa456afde361c9050d6f5188312ed4727136bbcb00a3c49e8f"},
 ]
 
 [package.dependencies]
 numpy = "*"
-torch = "2.2.0"
+pyre-extensions = "0.0.29"
+torch = "2.0.0"
 
 [[package]]
 name = "xxhash"
@@ -4415,4 +4341,4 @@ all = ["datasets", "evaluate", "faiss-cpu", "ipywidgets", "nltk", "numpy", "open
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "0cf03b59083453cf2bae29fa3d918619f5cee41bcb1b9ff4558e5ec4a61211f8"
+content-hash = "5a867ae36410a860853c2c9e4eb085dc2d13054ff57c1196677305116c6925dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,13 @@ whylogs = {url = "https://whypy.s3.us-west-2.amazonaws.com/whylogs-1.3.23.dev1-p
 
 
 # optional dependencies
-torch = {version = "*", optional = true}
+torch = {version = "2.0.0", optional = true, source = "torch"}
+
 numpy = {version = "*", optional = true}
 xformers = {version = "*", platform="!macos", python=">=3.8.0,<4", optional = true}
 datasets = {version ="^2.12.0", optional = true}
 openai = {version =">=0.27.6, <2.0.0", optional = true}
-nltk = {version ="^3.8.1", optional = true}
+nltk = {version = "^3.8", optional = true}
 sentence-transformers = {version ="^2.2.2", optional = true}
 evaluate = {version = "^0.4.0", optional = true}
 faiss-cpu = {version = "^1.7.1", optional = true}
@@ -37,6 +38,12 @@ bump2version = { version = "^1.0.1", python = ">=3.8.1,<4" }
 pyright = "^1.1.339"
 ruff = "^0.1.7"
 pandas-stubs = "2.0.0.230412"  # Last one that works with python 3.8
+
+[[tool.poetry.source]]
+name = "torch"
+url = "https://download.pytorch.org/whl/cu118"
+priority = "explicit"
+
 
 [tool.poetry.extras]
 all = [

--- a/tests/langkit/metrics/conftest.py
+++ b/tests/langkit/metrics/conftest.py
@@ -1,0 +1,4 @@
+from langkit.core.workflow import EvaluationWorkflow
+from langkit.metrics.library import lib
+
+wf = EvaluationWorkflow([lib.all_metrics()])


### PR DESCRIPTION
This enables bypassing the asset caching step of the metrics, which is sometimes required to work around the underlying library apis that always send http requests, regardless of the cache status (nltk).