### PR TITLE
response hallucination - expose error caught when calling openai

### DIFF
--- a/langkit/response_hallucination.py
+++ b/langkit/response_hallucination.py
@@ -105,6 +105,8 @@ class ConsistencyChecker:
             response: ChatLog = Conversation(self.sample_generator_llm).send_prompt(
                 prompt
             )
+            if response.errors:
+                raise Exception(f"Response Hallucination - Error generating sample: {response.errors}")
             samples.append(response)
         return samples
 

--- a/langkit/response_hallucination.py
+++ b/langkit/response_hallucination.py
@@ -106,7 +106,9 @@ class ConsistencyChecker:
                 prompt
             )
             if response.errors:
-                raise Exception(f"Response Hallucination - Error generating sample: {response.errors}")
+                raise Exception(
+                    f"Response Hallucination - Error generating sample: {response.errors}"
+                )
             samples.append(response)
         return samples
 


### PR DESCRIPTION
`response_hallucination` wasn't checking for errors when calling Openai with `openai.send_prompt`. This would lead to uninformative errors when, for example, not providing the openai with `response_hallucination`.

This PR checks the Chatlog response for errors and raises them if present.

closes #245 