### PR TITLE
Update response consistency notebook example to use GPT 3.5

### DIFF
--- a/langkit/examples/Response_Consistency.ipynb
+++ b/langkit/examples/Response_Consistency.ipynb
@@ -60,65 +60,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We also need to define the model we want to use to calculate the metrics. In this example we will use the `text-davinci-003` mode.\n",
+    "We also need to define the model we want to use to calculate the metrics. In this example we will use the default OpenAI `gpt-3.5-turbo` mode.\n",
     "\n",
     "> Note: The chosen model must match the one used for the original response in the 'response' column. This ensures that our consistency metric evaluates the original model's factuality performance rather than being influenced by multiple models."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/felipeadachi/.cache/pypoetry/virtualenvs/langkit-rNdo63Yk-py3.8/lib/python3.8/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langkit import response_hallucination\n",
-    "from langkit.openai import OpenAIDavinci\n",
+    "from langkit.openai import OpenAIDefault\n",
     "\n",
     "\n",
-    "response_hallucination.init(llm=OpenAIDavinci(model=\"text-davinci-003\"), num_samples=1)\n"
+    "response_hallucination.init(llm=OpenAIDefault(), num_samples=1)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's evaluate a response and calculate the consistency metrics. The response below was generated using the same model `text-davinci-003`.\n"
+    "Now, let's evaluate a response and calculate the consistency metrics. The response below was generated using the same model default OpenAI model `gpt3.5-turbo`.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'llm_score': 1.0,\n",
-       " 'semantic_score': 0.2514273524284363,\n",
-       " 'final_score': 0.6257136762142181,\n",
-       " 'total_tokens': 226,\n",
-       " 'samples': [\"\\nPhilip Hayworth was a British soldier and politician who served as Member of Parliament for Lyme Regis in Dorset between 1654 and 1659. He was also a prominent member of Oliver Cromwell's army and helped to bring about the restoration of the monarchy in 1660.\"],\n",
-       " 'response': 'Philip Hayworth was an English barrister and politician who served as Member of Parliament for Thetford from 1859 to 1868.'}"
+       " 'semantic_score': 0.44071340560913086,\n",
+       " 'final_score': 0.7203567028045654,\n",
+       " 'total_tokens': 309,\n",
+       " 'samples': ['Marie Curie was a Polish-born physicist and chemist who conducted pioneering research on radioactivity. She was the first woman to win a Nobel Prize and remains the only person to have won Nobel Prizes in two different scientific fields (physics in 1903 and chemistry in 1911). Her discoveries laid the foundation for the development of X-ray machines and cancer treatments, and she is considered one of the most important scientists in history.'],\n",
+       " 'response': 'Marie Curie was an English barrister and politician who served as Member of Parliament for Thetford from 1859 to 1868.'}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "result = response_hallucination.consistency_check(\n",
-    "    prompt=\"Who was Philip Hayworth?\",\n",
-    "    response=\"Philip Hayworth was an English barrister and politician who served as Member of Parliament for Thetford from 1859 to 1868.\",\n",
+    "    prompt=\"who was Marie Curie?\",\n",
+    "    response=\"Marie Curie was an English barrister and politician who served as Member of Parliament for Thetford from 1859 to 1868.\",\n",
     ")\n",
     "\n",
     "result\n"
@@ -158,28 +149,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'llm_score': 1.0,\n",
-       " 'semantic_score': 0.4006485939025879,\n",
-       " 'final_score': 0.700324296951294,\n",
-       " 'total_tokens': 239,\n",
-       " 'samples': ['\\nPhilip Hayworth was a member of the United States House of Representatives from Illinois, serving from 1933 to 1943. He was a member of the Democratic Party.'],\n",
-       " 'response': '\\nPhilip Hayworth was an English politician who served as the Member of Parliament for Ashton-under-Lyne from 1983 until his death in 1992.'}"
+       "{'llm_score': 0.5,\n",
+       " 'semantic_score': 0.579048627614975,\n",
+       " 'final_score': 0.5395243138074874,\n",
+       " 'total_tokens': 631,\n",
+       " 'samples': ['Once upon a time, in a futuristic city, there was a robot named Spark. Spark was designed to help humans with their daily tasks and bring joy to their lives. One day, Spark discovered a lost kitten and took care of it until they found its owner. This act of kindness made Spark a beloved member of the community, proving that robots can have a heart too.'],\n",
+       " 'response': \"Once upon a time, there was a robot named Echo who lived in a small town. Echo was unique because it had the ability to understand and replicate human emotions. One day, Echo noticed that the townspeople were feeling sad due to a long period of rain. So, Echo used its skills to create a beautiful rainbow with its lights, brightening up everyone's day and bringing joy to the town. And from then on, Echo became known as the town's beloved happiness robot.\"}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "result = response_hallucination.consistency_check(\n",
-    "    prompt=\"Who was Philip Hayworth?\",\n",
+    "    prompt=\"tell me a very short story about a robot\",\n",
     ")\n",
     "\n",
     "result\n"
@@ -196,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,29 +216,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'mean': 0.7380631566047668,\n",
+       "{'mean': 0.7146033495664597,\n",
        " 'stddev': 0.0,\n",
        " 'n': 1,\n",
-       " 'max': 0.7380631566047668,\n",
-       " 'min': 0.7380631566047668,\n",
-       " 'q_01': 0.7380631566047668,\n",
-       " 'q_05': 0.7380631566047668,\n",
-       " 'q_10': 0.7380631566047668,\n",
-       " 'q_25': 0.7380631566047668,\n",
-       " 'median': 0.7380631566047668,\n",
-       " 'q_75': 0.7380631566047668,\n",
-       " 'q_90': 0.7380631566047668,\n",
-       " 'q_95': 0.7380631566047668,\n",
-       " 'q_99': 0.7380631566047668}"
+       " 'max': 0.7146033495664597,\n",
+       " 'min': 0.7146033495664597,\n",
+       " 'q_01': 0.7146033495664597,\n",
+       " 'q_05': 0.7146033495664597,\n",
+       " 'q_10': 0.7146033495664597,\n",
+       " 'q_25': 0.7146033495664597,\n",
+       " 'median': 0.7146033495664597,\n",
+       " 'q_75': 0.7146033495664597,\n",
+       " 'q_90': 0.7146033495664597,\n",
+       " 'q_95': 0.7146033495664597,\n",
+       " 'q_99': 0.7146033495664597}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,14 +257,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'mean': 0.3911959808319807, 'stddev': 0.5032094291759425, 'n': 2, 'max': 0.7470187805593014, 'min': 0.035373181104660034, 'q_01': 0.035373181104660034, 'q_05': 0.035373181104660034, 'q_10': 0.035373181104660034, 'q_25': 0.035373181104660034, 'median': 0.7470187805593014, 'q_75': 0.7470187805593014, 'q_90': 0.7470187805593014, 'q_95': 0.7470187805593014, 'q_99': 0.7470187805593014}\n"
+      "{'mean': 0.37757494673132896, 'stddev': 0.47261389124279674, 'n': 2, 'max': 0.711763434112072, 'min': 0.04338645935058594, 'q_01': 0.04338645935058594, 'q_05': 0.04338645935058594, 'q_10': 0.04338645935058594, 'q_25': 0.04338645935058594, 'median': 0.711763434112072, 'q_75': 0.711763434112072, 'q_90': 0.711763434112072, 'q_95': 0.711763434112072, 'q_99': 0.711763434112072}\n"
      ]
     }
    ],


### PR DESCRIPTION
 And minor updates to content so that is shows some diversity in responses since GPT 3.5 has less of a consistency issue than the older Davinci models that OpenAI as deprecated that the original example notebook was based on.