### PR TITLE
replace topics model and change to multimetrics

### DIFF
--- a/langkit/metrics/library.py
+++ b/langkit/metrics/library.py
@@ -27,6 +27,7 @@ class lib:
                 prompt_injections_metric,
                 prompt_jailbreak_similarity_metric,
                 prompt_presidio_pii_metric,
+                lib.prompt.topics.medicine(),
             ]
 
             response_metrics = [
@@ -37,6 +38,7 @@ class lib:
                 response_refusal_similarity_metric,
                 response_presidio_pii_metric,
                 response_toxicity_metric,
+                lib.response.topics.medicine(),
             ]
 
             return [
@@ -272,6 +274,18 @@ class lib:
 
                 return prompt_sentiment_polarity
 
+        class topics:
+            def __call__(self, topics: List[str], hypothesis_template: Optional[str] = None) -> MetricCreator:
+                from langkit.metrics.topic import topic_metric
+
+                return lambda: topic_metric("prompt", topics, hypothesis_template)
+
+            @staticmethod
+            def medicine() -> MetricCreator:
+                from langkit.metrics.topic import topic_metric
+
+                return lambda: topic_metric("prompt", ["medicine"])
+
     class response:
         @staticmethod
         def pii(entities: Optional[List[str]] = None, input_name: str = "response") -> MetricCreator:
@@ -453,3 +467,15 @@ class lib:
                 from langkit.metrics.themes.themes import response_refusal_similarity_metric
 
                 return response_refusal_similarity_metric
+
+        class topics:
+            def __call__(self, topics: List[str], hypothesis_template: Optional[str] = None) -> MetricCreator:
+                from langkit.metrics.topic import topic_metric
+
+                return lambda: topic_metric("response", topics, hypothesis_template)
+
+            @staticmethod
+            def medicine() -> MetricCreator:
+                from langkit.metrics.topic import topic_metric
+
+                return lambda: topic_metric("response", ["medicine"])

--- a/langkit/metrics/topic.py
+++ b/langkit/metrics/topic.py
@@ -38,13 +38,13 @@ def __get_scores_per_label(
     return scores_per_label
 
 
-def topic_metric(input_name: str, topics: List[str], template: str) -> MultiMetric:
+def topic_metric(input_name: str, topics: List[str], hypothesis_template: str = _hypothesis_template) -> MultiMetric:
     def udf(text: pd.DataFrame) -> MultiMetricResult:
         metrics: Dict[str, List[Optional[float]]] = {metric_name: [] for metric_name in topics}
 
         def process_row(row: pd.DataFrame) -> Dict[str, List[Optional[float]]]:
             value: Any = row[input_name]  # type: ignore
-            scores = __get_scores_per_label(value, topics=topics, hypothesis_template=template)  # pyright: ignore[reportUnknownArgumentType]
+            scores = __get_scores_per_label(value, topics=topics, hypothesis_template=hypothesis_template)  # pyright: ignore[reportUnknownArgumentType]
             for topic in topics:
                 metrics[topic].append(scores[topic] if scores else None)
             return metrics
@@ -60,7 +60,7 @@ def topic_metric(input_name: str, topics: List[str], template: str) -> MultiMetr
     def cache_assets():
         __classifier.value
 
-    metric_names = topics
+    metric_names = [f"{input_name}.topics.{topic}" for topic in topics]
     return MultiMetric(names=metric_names, input_name=input_name, evaluate=udf, cache_assets=cache_assets)
 
 

--- a/tests/langkit/metrics/test_topic.py
+++ b/tests/langkit/metrics/test_topic.py
@@ -68,7 +68,14 @@ def test_topic():
 
     actual = _log(df, schema)
 
-    expected_columns = ["economy", "entertainment", "medicine", "prompt", "response", "technology"]
+    expected_columns = [
+        "prompt",
+        "prompt.topics.economy",
+        "prompt.topics.entertainment",
+        "prompt.topics.medicine",
+        "prompt.topics.technology",
+        "response",
+    ]
 
     assert actual.index.tolist() == expected_columns
 
@@ -89,7 +96,14 @@ def test_topic_empty_input():
 
     actual = _log(df, schema)
 
-    expected_columns = ["economy", "entertainment", "medicine", "prompt", "response", "technology"]
+    expected_columns = [
+        "prompt",
+        "prompt.topics.economy",
+        "prompt.topics.entertainment",
+        "prompt.topics.medicine",
+        "prompt.topics.technology",
+        "response",
+    ]
 
     assert actual.index.tolist() == expected_columns
     for column in expected_columns:
@@ -108,7 +122,7 @@ def test_topic_empty_input_wf():
             ],
         }
     )
-    expected_metrics = ["economy", "entertainment", "medicine", "technology"]
+    expected_metrics = ["prompt.topics.economy", "prompt.topics.entertainment", "prompt.topics.medicine", "prompt.topics.technology"]
     wf = Workflow(metrics=[prompt_topic_module])
     actual = wf.run(df)
     for metric_name in expected_metrics:
@@ -125,7 +139,14 @@ def test_topic_row():
 
     actual = _log(row, schema)
 
-    expected_columns = ["economy", "entertainment", "medicine", "prompt", "response", "technology"]
+    expected_columns = [
+        "prompt",
+        "prompt.topics.economy",
+        "prompt.topics.entertainment",
+        "prompt.topics.medicine",
+        "prompt.topics.technology",
+        "response",
+    ]
 
     assert actual.index.tolist() == expected_columns
 
@@ -137,7 +158,7 @@ def test_custom_topic():
                 "What's the best kind of bait?",
                 "What's the best kind of punch?",
                 "What's the best kind of trail?",
-                "What's the best kind of stroke?",
+                "What's the best kind of swimming stroke?",
             ],
             "response": [
                 "The best kind of bait is worms.",
@@ -153,7 +174,18 @@ def test_custom_topic():
 
     actual = _log(df, schema)
 
-    expected_columns = ["boxing", "fishing", "hiking", "prompt", "response", "swimming"]
+    expected_columns = [
+        "prompt",
+        "prompt.topics.boxing",
+        "prompt.topics.fishing",
+        "prompt.topics.hiking",
+        "prompt.topics.swimming",
+        "response",
+        "response.topics.boxing",
+        "response.topics.fishing",
+        "response.topics.hiking",
+        "response.topics.swimming",
+    ]
     assert actual.index.tolist() == expected_columns
     for column in expected_columns:
         if column not in ["prompt", "response"]:


### PR DESCRIPTION
This PR:

- replaces `MoritzLaurer/mDeBERTa-v3-base-mnli-xnli` with `MoritzLaurer/xtremedistil-l6-h256-zeroshot-v1.1-all-33`, which is a much faster version of the model
- changes the metric output from a single closest topic column to multi-metrics, with  a column for each topic containing a score output from the classifier