### PR TITLE
update pip install in injection example

### DIFF
--- a/langkit/examples/Injections.ipynb
+++ b/langkit/examples/Injections.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U langkit[all]"
+    "%pip install -U 'langkit[all]'"
    ]
   },
   {


### PR DESCRIPTION
## Description

There were some issues with the pip install commands in notebook.

- langkit install was not functional in the local VSCode environment

## Changes

Considering this, changes were made:

- Added quotes around 'langkit[all]' to ensure functional install in more environments