### PR TITLE
Fix rolling logger schema

### DIFF
--- a/langkit/whylogs/rolling_logger.py
+++ b/langkit/whylogs/rolling_logger.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
 import whylogs as why
 from whylogs.core.schema import DatasetSchema
-from langkit import llm_metrics
 
 
 class RollingLogger:
@@ -12,15 +11,22 @@ class RollingLogger:
         schema: Optional[DatasetSchema] = None,
         **kwargs: Any
     ):
-        llm_schema = llm_metrics.init()
+        if schema is None:
+            from langkit import llm_metrics
+
+            schema = llm_metrics.init()
         self.logger = why.logger(
             mode="rolling",
             interval=interval_minutes,
             when="M",
             base_name="langkit",
-            schema=llm_schema,
+            schema=schema,
         )
-        self.logger.append_writer(name="whylabs", **kwargs)
+
+        if "writer" in kwargs:
+            self.logger.append_writer(name=None, **kwargs)
+        else:
+            self.logger.append_writer(name="whylabs", **kwargs)
 
     def log(self, dict):
         self.logger.log(dict)


### PR DESCRIPTION
Fix the rolling logger helper class to support:
* passing in a custom schema that avoids the llm_metrics init call for local mode
* default to using the llm_metrics only if no schema is passed in
* default to whylabs writer if no writer is passed in